### PR TITLE
re-export `metrics` (and `statistics`) from `pytorch-ie`

### DIFF
--- a/src/pie_modules/metrics/__init__.py
+++ b/src/pie_modules/metrics/__init__.py
@@ -1,1 +1,9 @@
+from pytorch_ie.metrics import F1Metric
+from pytorch_ie.metrics.statistics import (
+    FieldLengthCollector,
+    LabelCountCollector,
+    SubFieldLengthCollector,
+    TokenCountCollector,
+)
+
 from .span_length_collector import SpanLengthCollector


### PR DESCRIPTION
This implements #12.