### PR TITLE
fix annotations that are reported as missing after tokenization

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1057,23 +1057,27 @@ files = [
 
 [[package]]
 name = "pytorch-ie"
-version = "0.29.2"
+version = "0.29.3"
 description = "State-of-the-art Information Extraction in PyTorch"
 optional = false
-python-versions = ">=3.9,<4.0"
-files = [
-    {file = "pytorch_ie-0.29.2-py3-none-any.whl", hash = "sha256:73908f8a6b43e9484a8a463ce601e50367fbdca9e7be44d83608b1f035502bb1"},
-    {file = "pytorch_ie-0.29.2.tar.gz", hash = "sha256:9c0b43b43307107c963e927336a0083a7f4fa4ca224b1447999848eedddde0d7"},
-]
+python-versions = "^3.9"
+files = []
+develop = false
 
 [package.dependencies]
-absl-py = ">=1.0.0,<2.0.0"
+absl-py = "^1.0.0"
 fsspec = "<2023.9.0"
-pandas = ">=2.0.0,<3.0.0"
-pytorch-lightning = ">=2,<3"
+pandas = "^2.0.0"
+pytorch-lightning = "^2"
 torch = ">=1.10"
-torchmetrics = ">=1,<2"
-transformers = ">=4.18,<5.0"
+torchmetrics = "^1"
+transformers = "^4.18"
+
+[package.source]
+type = "git"
+url = "https://github.com/ChristophAlt/pytorch-ie.git"
+reference = "add_all_annotations_from_other_returns_added"
+resolved_reference = "f3dc4c4f6a5cea134cfd987bfc9bb88c58f3bf07"
 
 [[package]]
 name = "pytorch-lightning"
@@ -1893,4 +1897,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "b5176d117ab53867c8ec43e915aabf693c744511ae207ef46cec1e04da85cd4b"
+content-hash = "3718668219a406000f5b345300354d7e260bb09f79a3aa47b6228fc01460c267"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1057,27 +1057,23 @@ files = [
 
 [[package]]
 name = "pytorch-ie"
-version = "0.29.3"
+version = "0.29.4"
 description = "State-of-the-art Information Extraction in PyTorch"
 optional = false
-python-versions = "^3.9"
-files = []
-develop = false
+python-versions = ">=3.9,<4.0"
+files = [
+    {file = "pytorch_ie-0.29.4-py3-none-any.whl", hash = "sha256:40117d4d17866088cd50f18e9abc5ccf7b4c7e1599c54b7de4fdcbb601e01c11"},
+    {file = "pytorch_ie-0.29.4.tar.gz", hash = "sha256:903a82ff6701a583a587c00420907a0d8af6fe5de56ae3de1111344cad00fc1b"},
+]
 
 [package.dependencies]
-absl-py = "^1.0.0"
+absl-py = ">=1.0.0,<2.0.0"
 fsspec = "<2023.9.0"
-pandas = "^2.0.0"
-pytorch-lightning = "^2"
+pandas = ">=2.0.0,<3.0.0"
+pytorch-lightning = ">=2,<3"
 torch = ">=1.10"
-torchmetrics = "^1"
-transformers = "^4.18"
-
-[package.source]
-type = "git"
-url = "https://github.com/ChristophAlt/pytorch-ie.git"
-reference = "add_all_annotations_from_other_returns_added"
-resolved_reference = "f3dc4c4f6a5cea134cfd987bfc9bb88c58f3bf07"
+torchmetrics = ">=1,<2"
+transformers = ">=4.18,<5.0"
 
 [[package]]
 name = "pytorch-lightning"
@@ -1897,4 +1893,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "3718668219a406000f5b345300354d7e260bb09f79a3aa47b6228fc01460c267"
+content-hash = "59bcfdd8d5c32d19dcf90688443331d317ddc614abe1e5479df82f31f3649845"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,9 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.9"
-pytorch-ie = ">=0.29.2,<0.30.0"
+# pytorch-ie = ">=0.29.2,<0.30.0"
+# we require pytorch-ie from branch add_all_annotations_from_other_returns_added
+pytorch-ie = {git = "https://github.com/ChristophAlt/pytorch-ie.git", branch = "add_all_annotations_from_other_returns_added"}
 torchmetrics = "^1"
 pytorch-crf = ">=0.7.2"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,9 +24,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.9"
-# pytorch-ie = ">=0.29.2,<0.30.0"
-# we require pytorch-ie from branch add_all_annotations_from_other_returns_added
-pytorch-ie = {git = "https://github.com/ChristophAlt/pytorch-ie.git", branch = "add_all_annotations_from_other_returns_added"}
+pytorch-ie = ">=0.29.4,<0.30.0"
 torchmetrics = "^1"
 pytorch-crf = ">=0.7.2"
 

--- a/src/pie_modules/document/processing/tokenization.py
+++ b/src/pie_modules/document/processing/tokenization.py
@@ -63,7 +63,7 @@ def text_based_document_to_token_based(
     char_to_token: Optional[Callable[[int], Optional[int]]] = None,
     strict_span_conversion: bool = True,
     verbose: bool = True,
-    added_annotations: Optional[Dict[str, Set[Annotation]]] = None,
+    added_annotations: Optional[Dict[str, List[Annotation]]] = None,
 ) -> ToD:
     document_type = resolve_type(
         type_or_str=result_document_type, expected_super_type=TokenBasedDocument
@@ -165,7 +165,7 @@ def text_based_document_to_token_based(
                 token_span = char_span.copy(start=start_token_idx, end=end_token_idx_inclusive + 1)
                 override_annotations[text_targeting_layer_name][char_span._id] = token_span
                 if added_annotations is not None:
-                    added_annotations[text_targeting_layer_name].add(char_span)
+                    added_annotations[text_targeting_layer_name].append(char_span)
         valid_spans = set(override_annotations[text_targeting_layer_name].values())
         result[text_targeting_layer_name].extend(sorted(valid_spans, key=lambda span: span.start))
 
@@ -178,7 +178,7 @@ def text_based_document_to_token_based(
     )
     if added_annotations is not None:
         for layer_name, annotations in added_annotations_from_remaining_layers.items():
-            added_annotations[layer_name].update(annotations)
+            added_annotations[layer_name].extend(annotations)
 
     return result
 
@@ -191,7 +191,7 @@ def token_based_document_to_text_based(
     join_tokens_with: Optional[str] = None,
     strict_span_conversion: bool = True,
     verbose: bool = True,
-    added_annotations: Optional[Dict[str, Set[Annotation]]] = None,
+    added_annotations: Optional[Dict[str, List[Annotation]]] = None,
 ) -> TeD:
     document_type = resolve_type(
         type_or_str=result_document_type, expected_super_type=TextBasedDocument
@@ -267,7 +267,7 @@ def token_based_document_to_text_based(
             char_span = token_span.copy(start=start_char_idx, end=end_char_idx)
             override_annotations[token_targeting_layer_name][token_span._id] = char_span
             if added_annotations is not None:
-                added_annotations[token_targeting_layer_name].add(token_span)
+                added_annotations[token_targeting_layer_name].append(token_span)
         valid_spans = set(override_annotations[token_targeting_layer_name].values())
         result[token_targeting_layer_name].extend(sorted(valid_spans, key=lambda span: span.start))
 
@@ -280,7 +280,7 @@ def token_based_document_to_text_based(
     )
     if added_annotations is not None:
         for layer_name, annotations in added_annotations_from_remaining_layers.items():
-            added_annotations[layer_name].update(annotations)
+            added_annotations[layer_name].extend(annotations)
 
     return result
 
@@ -294,7 +294,7 @@ def tokenize_document(
     verbose: bool = True,
     **tokenize_kwargs,
 ) -> List[ToD]:
-    added_annotations: Dict[str, Set[Annotation]] = defaultdict(set)
+    added_annotations: Dict[str, List[Annotation]] = defaultdict(list)
     result = []
     partitions: Iterable[Span]
     if partition_layer is None:

--- a/tests/document/processing/test_tokenization.py
+++ b/tests/document/processing/test_tokenization.py
@@ -1,4 +1,5 @@
 import dataclasses
+from collections import defaultdict
 
 import pytest
 from pytorch_ie.annotations import BinaryRelation, Label, LabeledSpan, Span
@@ -152,11 +153,16 @@ def test_find_token_offset_mapping(text_document, token_document):
 
 
 def test_text_based_document_to_token_based(text_document, token_document):
+    added_annotations = defaultdict(list)
     doc = text_based_document_to_token_based(
         text_document,
         tokens=list(token_document.tokens),
         result_document_type=TokenizedTestDocument,
+        added_annotations=added_annotations,
     )
+    for ann_field in text_document.annotation_fields():
+        layer_name = ann_field.name
+        assert added_annotations[layer_name] == list(text_document[layer_name])
     _test_token_document(doc)
 
 
@@ -310,11 +316,17 @@ def test_text_based_document_to_token_based_wrong_annotation_type():
 
 
 def test_token_based_document_to_text_based(token_document, text_document):
+    added_annotations = defaultdict(list)
     result = token_based_document_to_text_based(
         token_document,
         text=text_document.text,
         result_document_type=TestDocument,
+        added_annotations=added_annotations,
     )
+    for ann_field in token_document.annotation_fields():
+        layer_name = ann_field.name
+        assert added_annotations[layer_name] == list(token_document[layer_name])
+
     _test_text_document(result)
 
 

--- a/tests/document/processing/test_tokenization.py
+++ b/tests/document/processing/test_tokenization.py
@@ -541,6 +541,29 @@ def test_tokenize_document_max_length(text_document, tokenizer, caplog):
     assert relation_tuples == [("('it',)", "per:founder", "('O',)")]
 
 
+def test_tokenize_document_max_length_strict(text_document, tokenizer):
+    with pytest.raises(ValueError) as excinfo:
+        tokenize_document(
+            text_document,
+            tokenizer=tokenizer,
+            result_document_type=TokenizedTestDocument,
+            # max_length is set to 10, so the document is split into two parts
+            strict_span_conversion=True,
+            max_length=10,
+            return_overflowing_tokens=True,
+        )
+    assert (
+        str(excinfo.value)
+        == "could not convert all annotations from document with id=None to token based documents, "
+        "but strict_span_conversion is True, so raise an error, missed annotations:\n"
+        "{\n"
+        '  "relations": "{BinaryRelation(head=LabeledSpan(start=16, end=24, label=\'per\', score=1.0), '
+        "tail=LabeledSpan(start=34, end=35, label='org', score=1.0), label='per:employee_of', score=1.0)}\",\n"
+        '  "sentences": "{Span(start=16, end=36)}"\n'
+        "}"
+    )
+
+
 def test_tokenize_document_partition(text_document, tokenizer):
     tokenized_docs = tokenize_document(
         text_document,


### PR DESCRIPTION
This PR fixes which annotations are reported as missing after tokenization. When `tokenize_document()` returns multiple documents because of partitioning or windowing, the annotations are distributed on the respective result documents. This means, that each result document may lack some annotations but these may be still covered by other result docs. With this PR, we only report the annotations as missing that are not added to *any* of the result documents (e.g. spans because of alignment errors or relations because their arguments are in different result documents).

This requires: https://github.com/ChristophAlt/pytorch-ie/pull/390 (i.e. `pytorch-ie>=0.29.4`)