### PR TITLE
set `pytorch-lightning="^2.1.0" `

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1893,4 +1893,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "59bcfdd8d5c32d19dcf90688443331d317ddc614abe1e5479df82f31f3649845"
+content-hash = "ac5cd413d391807563d27d9d94098c85db61b2fbfecb6c2bf90a03fe50c0f003"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
 [tool.poetry.dependencies]
 python = "^3.9"
 pytorch-ie = ">=0.29.4,<0.30.0"
+pytorch-lightning = "^2.1.0"
 torchmetrics = "^1"
 pytorch-crf = ">=0.7.2"
 


### PR DESCRIPTION
This PR fixes a regression introduced in #14: the `OptimizerLRScheduler` type used in the EQA model requires `pytorch-lightning="^2.1.0" `