### PR TITLE
post PR26 fixes

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1943,4 +1943,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "eef4937e046b009d6fa3abfccef0c7016a221e50d1fac405dcfbba739f56c951"
+content-hash = "7ee372400ee6af659fef615e36edca6749e49933682a33d95484da51358d7fa0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,8 @@ pytorch-ie = ">=0.29.5,<0.30.0"
 pytorch-lightning = "^2.1.0"
 torchmetrics = "^1"
 pytorch-crf = ">=0.7.2"
+# because of BartModelWithDecoderPositionIds
+transformers = "^4.35.0"
 
 [tool.poetry.group.dev.dependencies]
 torch = {version = "^2.1.0+cpu", source = "pytorch"}

--- a/src/pie_modules/models/base_models/__init__.py
+++ b/src/pie_modules/models/base_models/__init__.py
@@ -1,0 +1,1 @@
+from .bart_with_decoder_position_ids import BartModelWithDecoderPositionIds

--- a/tests/models/base_models/test_bart_with_decoder_position_ids.py
+++ b/tests/models/base_models/test_bart_with_decoder_position_ids.py
@@ -2,19 +2,13 @@ import pytest
 import torch
 from torch.nn import Embedding
 from transformers import BartConfig
-from transformers.modeling_outputs import (
-    BaseModelOutputWithPastAndCrossAttentions,
-    Seq2SeqModelOutput,
-)
-from transformers.models.bart.modeling_bart import (
-    BartEncoder,
-    BartLearnedPositionalEmbedding,
-)
+from transformers.modeling_outputs import BaseModelOutputWithPastAndCrossAttentions
+from transformers.models.bart.modeling_bart import BartEncoder
 
+from pie_modules.models.base_models import BartModelWithDecoderPositionIds
 from pie_modules.models.base_models.bart_with_decoder_position_ids import (
     BartDecoderWithPositionIds,
     BartLearnedPositionalEmbeddingWithPositionIds,
-    BartModelWithDecoderPositionIds,
 )
 
 


### PR DESCRIPTION
This was missed in #26:
 - export `BartModelWithDecoderPositionIds` directly from `models.base_models`
 - set dependency `transformers = "^4.35.0"` because of `BartModelWithDecoderPositionIds `