### PR TITLE
skip overlapping spans instead of skipping whole documents

### DIFF
--- a/src/pie_modules/taskmodules/token_classification.py
+++ b/src/pie_modules/taskmodules/token_classification.py
@@ -270,7 +270,8 @@ class TokenClassificationTaskModule(TaskModuleType):
             raise ValueError(
                 "'labels' must be set before calling encode_target(). Was prepare() called on the taskmodule?"
             )
-        for span in tokenized_document.labeled_spans:
+        sorted_spans = sorted(tokenized_document.labeled_spans, key=lambda s: (s.start, s.end))
+        for span in sorted_spans:
             if span.label not in self.labels:
                 continue
             start = span.start

--- a/src/pie_modules/taskmodules/token_classification.py
+++ b/src/pie_modules/taskmodules/token_classification.py
@@ -278,7 +278,7 @@ class TokenClassificationTaskModule(TaskModuleType):
             end = span.end
             if any(tag != "O" for tag in tag_sequence[start:end]):
                 logger.warning(f"tag already assigned (current span has an overlap: {span}).")
-                return None
+                continue
 
             tag_sequence[start] = f"B-{span.label}"
             for j in range(start + 1, end):

--- a/tests/taskmodules/test_token_classification.py
+++ b/tests/taskmodules/test_token_classification.py
@@ -355,12 +355,13 @@ def test_encode_targets_with_overlap(caplog):
     # encode the document
     with caplog.at_level(logging.WARNING):
         task_encodings = taskmodule.encode([doc], encode_target=True)
-    assert len(task_encodings) == 0
     assert len(caplog.records) == 1
     assert (
         caplog.messages[0]
         == "tag already assigned (current span has an overlap: ('bob', 'enjoys'))."
     )
+    assert len(task_encodings) == 1
+    assert task_encodings[0].targets == [-100, 3, 0, 0, 0, 0, 3, 0, 0, 0, 0, -100]
 
 
 @pytest.fixture(scope="module")

--- a/tests/taskmodules/test_token_classification.py
+++ b/tests/taskmodules/test_token_classification.py
@@ -334,6 +334,35 @@ def test_task_encodings(task_encodings, taskmodule, config):
         raise ValueError(f"unknown config: {config}")
 
 
+def test_encode_targets_with_overlap(caplog):
+    # setup taskmodule
+    taskmodule = TokenClassificationTaskModule(
+        tokenizer_name_or_path="bert-base-uncased", labels=["LOC", "PER"]
+    )
+    taskmodule.post_prepare()
+
+    # create a document with overlapping entities
+    doc = TextDocumentWithLabeledSpans(
+        text="Alice loves reading books. Bob enjoys playing soccer."
+    )
+    doc.labeled_spans.append(LabeledSpan(start=0, end=5, label="PER"))
+    doc.labeled_spans.append(LabeledSpan(start=27, end=30, label="PER"))
+    doc.labeled_spans.append(LabeledSpan(start=27, end=37, label="PER"))
+    assert str(doc.labeled_spans[0]) == "Alice"
+    assert str(doc.labeled_spans[1]) == "Bob"
+    assert str(doc.labeled_spans[2]) == "Bob enjoys"
+
+    # encode the document
+    with caplog.at_level(logging.WARNING):
+        task_encodings = taskmodule.encode([doc], encode_target=True)
+    assert len(task_encodings) == 0
+    assert len(caplog.records) == 1
+    assert (
+        caplog.messages[0]
+        == "tag already assigned (current span has an overlap: ('bob', 'enjoys'))."
+    )
+
+
 @pytest.fixture(scope="module")
 def task_encodings_for_batch(task_encodings, config):
     # just take everything we have


### PR DESCRIPTION
This fixes #28.