### PR TITLE
Fix state of wrapped layer metrics with unbatch and decode with errors function

### DIFF
--- a/src/pie_modules/taskmodules/metrics/common.py
+++ b/src/pie_modules/taskmodules/metrics/common.py
@@ -1,0 +1,36 @@
+import logging
+from abc import ABC
+from typing import Dict, Optional
+
+import torch
+from torch import LongTensor
+from torchmetrics import Metric
+
+logger = logging.getLogger(__name__)
+
+
+class MetricWithArbitraryCounts(Metric, ABC):
+    """A metric that hold counts for arbitrary keys."""
+
+    def inc_counts(self, counts: LongTensor, key: Optional[str], prefix: str = "counts_"):
+        full_key = prefix
+        if key is not None:
+            full_key += key
+
+        if not hasattr(self, full_key):
+            self.add_state(full_key, default=torch.zeros_like(counts), dist_reduce_fx="sum")
+
+        prev_value = getattr(self, full_key)
+        setattr(self, full_key, prev_value + counts)
+
+    def get_counts(self, key_prefix: str = "counts_") -> Dict[Optional[str], LongTensor]:
+        result = {}
+        for k, v in self.metric_state.items():
+            if k.startswith(key_prefix):
+                if not isinstance(v, LongTensor):
+                    raise ValueError(
+                        f"Expected metric state for key {k} to be a LongTensor, but got {type(v)}."
+                    )
+                key = k[len(key_prefix) :] or None
+                result[key] = v
+        return result

--- a/tests/taskmodules/metrics/test_wrapped_layer_metrics_with_unbatch_and_decode_with_errors_function.py
+++ b/tests/taskmodules/metrics/test_wrapped_layer_metrics_with_unbatch_and_decode_with_errors_function.py
@@ -2,7 +2,7 @@ import json
 from typing import Any, Dict, Tuple
 
 import pytest
-import torch
+from torch import tensor
 from torchmetrics import Metric
 
 from pie_modules.taskmodules.metrics import (
@@ -55,9 +55,8 @@ def test_wrapped_layer_metrics_with_unbatch_and_decode_with_errors_function(
     assert metric.decode_layers_with_errors_function is not None
     assert metric.layer_metrics is not None
     assert metric.metric_state == {
-        "total": torch.tensor(0),
-        "exact_encoding_matches": torch.tensor(0),
-        "errors": [],
+        "total": tensor(0),
+        "exact_encoding_matches": tensor(0),
     }
 
     values = metric.compute()
@@ -76,9 +75,9 @@ def test_wrapped_layer_metrics_with_unbatch_and_decode_with_errors_function(
         expected=json.dumps({"entities": ["E1"], "relations": ["R1"]}),
     )
     assert metric.metric_state == {
-        "total": torch.tensor(1),
-        "exact_encoding_matches": torch.tensor(1),
-        "errors": [("dummy", 0)],
+        "total": tensor(1),
+        "exact_encoding_matches": tensor(1),
+        "errors_dummy": tensor(0),
     }
     values = metric.compute()
     assert values == {
@@ -100,9 +99,9 @@ def test_wrapped_layer_metrics_with_unbatch_and_decode_with_errors_function(
         + json.dumps({"entities": ["E1"], "relations": ["R2"]}),
     )
     assert metric.metric_state == {
-        "total": torch.tensor(2),
-        "exact_encoding_matches": torch.tensor(1),
-        "errors": [("dummy", 0), ("dummy", 0)],
+        "total": tensor(2),
+        "exact_encoding_matches": tensor(1),
+        "errors_dummy": tensor(0),
     }
     values = metric.compute()
     assert values == {
@@ -119,9 +118,9 @@ def test_wrapped_layer_metrics_with_unbatch_and_decode_with_errors_function(
         expected=json.dumps({"entities": ["E1"], "relations": []}),
     )
     assert metric.metric_state == {
-        "total": torch.tensor(1),
-        "exact_encoding_matches": torch.tensor(0),
-        "errors": [("dummy", 1)],
+        "total": tensor(1),
+        "exact_encoding_matches": tensor(0),
+        "errors_dummy": tensor(1),
     }
     values = metric.compute()
     # In the case on an error, the decoding function returns adict with empty lists for entities and relations.


### PR DESCRIPTION
With this PR, the state of the metric `WrappedLayerMetricsWithUnbatchAndDecodeWithErrorsFunction`, especially the error counts, are now correctly handled.

This also adds the abstract metric class `MetricWithArbitraryCounts` that provides the methods `inc_counts()` and `get_counts()` to easily handle counts lazily for arbitrary keys. This was outsourced from `PrecisionRecallAndF1ForLabeledAnnotations`.