### PR TITLE
re-export `annotations` and `documents` from `pytorch_ie`

### DIFF
--- a/src/pie_modules/annotations.py
+++ b/src/pie_modules/annotations.py
@@ -1,7 +1,19 @@
 import dataclasses
 from typing import Optional
 
-from pytorch_ie.annotations import Span
+# re-export all annotations from pytorch_ie to have a single entry point
+from pytorch_ie.annotations import (
+    BinaryRelation,
+    Label,
+    LabeledMultiSpan,
+    LabeledSpan,
+    MultiLabel,
+    MultiLabeledBinaryRelation,
+    MultiLabeledMultiSpan,
+    MultiLabeledSpan,
+    NaryRelation,
+    Span,
+)
 from pytorch_ie.core import Annotation
 
 

--- a/src/pie_modules/documents.py
+++ b/src/pie_modules/documents.py
@@ -1,14 +1,32 @@
 import dataclasses
 
-from pytorch_ie import AnnotationLayer
-from pytorch_ie.annotations import BinaryRelation, LabeledSpan
-from pytorch_ie.core import AnnotationList, annotation_field
-from pytorch_ie.documents import TextBasedDocument, TokenBasedDocument
+from pytorch_ie.core import AnnotationLayer, AnnotationList, annotation_field
+
+# re-export all documents from pytorch_ie to have a single entry point
+from pytorch_ie.documents import (
+    TextBasedDocument,
+    TextDocumentWithLabel,
+    TextDocumentWithLabeledPartitions,
+    TextDocumentWithLabeledSpans,
+    TextDocumentWithLabeledSpansAndBinaryRelations,
+    TextDocumentWithLabeledSpansAndLabeledPartitions,
+    TextDocumentWithLabeledSpansAndSentences,
+    TextDocumentWithLabeledSpansBinaryRelationsAndLabeledPartitions,
+    TextDocumentWithMultiLabel,
+    TextDocumentWithSentences,
+    TextDocumentWithSpans,
+    TextDocumentWithSpansAndBinaryRelations,
+    TextDocumentWithSpansAndLabeledPartitions,
+    TextDocumentWithSpansBinaryRelationsAndLabeledPartitions,
+    TokenBasedDocument,
+)
 
 from pie_modules.annotations import (
     AbstractiveSummary,
+    BinaryRelation,
     ExtractiveAnswer,
     GenerativeAnswer,
+    LabeledSpan,
     Question,
 )
 


### PR DESCRIPTION
To have a single entry point and in preparation to move their implementations to `pie_modules`. This implements #11.