### PR TITLE
add multi-span documents

### DIFF
--- a/src/pie_modules/documents.py
+++ b/src/pie_modules/documents.py
@@ -119,3 +119,30 @@ class TokenDocumentWithAbstractiveSummary(TokenBasedDocument):
     """A tokenized PIE document with annotations for abstractive summarization."""
 
     abstractive_summary: AnnotationLayer[AbstractiveSummary] = annotation_field()
+
+
+@dataclasses.dataclass
+class TextDocumentWithLabeledMultiSpans(TextBasedDocument):
+    labeled_multi_spans: AnnotationLayer[LabeledSpan] = annotation_field(target="text")
+
+
+@dataclasses.dataclass
+class TextDocumentWithLabeledMultiSpansAndLabeledPartitions(
+    TextDocumentWithLabeledMultiSpans, TextDocumentWithLabeledPartitions
+):
+    pass
+
+
+@dataclasses.dataclass
+class TextDocumentWithLabeledMultiSpansAndBinaryRelations(TextDocumentWithLabeledMultiSpans):
+    binary_relations: AnnotationLayer[BinaryRelation] = annotation_field(
+        target="labeled_multi_spans"
+    )
+
+
+@dataclasses.dataclass
+class TextDocumentWithLabeledMultiSpansBinaryRelationsAndLabeledPartitions(
+    TextDocumentWithLabeledMultiSpansAndLabeledPartitions,
+    TextDocumentWithLabeledMultiSpansAndBinaryRelations,
+):
+    pass


### PR DESCRIPTION
This PR adds the following document types that contain `MultiSpan`s:
 - `TextDocumentWithLabeledMultiSpans`, 
 - `TextDocumentWithLabeledMultiSpansAndLabeledPartitions`, 
 - `TextDocumentWithLabeledMultiSpansAndBinaryRelations`, and
 - `TextDocumentWithLabeledMultiSpansBinaryRelationsAndLabeledPartitions`.