### PR TITLE
`PointerHead`: fix `increase_position_ids_per_record`

### DIFF
--- a/src/pie_modules/models/components/pointer_head.py
+++ b/src/pie_modules/models/components/pointer_head.py
@@ -157,7 +157,7 @@ class PointerHead(torch.nn.Module):
         if self.increase_position_ids_per_record:
             position_ids_reshaped = position_ids.view(bsz, -1, pattern_len)
             add_shift_pos = (
-                torch.range(0, repeat_num - 1, device=position_ids_reshaped.device)
+                torch.arange(0, repeat_num, device=position_ids_reshaped.device)
                 .repeat(bsz)
                 .view(bsz, -1)
                 .unsqueeze(-1)


### PR DESCRIPTION
this was broken if the input does not contain any full record