### PR TITLE
create `position_ids` based on a mapping (`PointerHead`)

### DIFF
--- a/src/pie_modules/models/base_models/bart_as_pointer_network.py
+++ b/src/pie_modules/models/base_models/bart_as_pointer_network.py
@@ -43,12 +43,14 @@ class BartAsPointerNetworkConfig(BartConfig):
         target_token_ids: Optional[List[int]] = None,
         # token id mapping to better initialize the label embedding weights
         embedding_weight_mapping: Optional[Dict[Union[int, str], List[int]]] = None,
+        # special decoder position id handling
+        decoder_position_id_mode: Optional[str] = None,
+        decoder_position_id_pattern: Optional[List[int]] = None,
+        decoder_position_id_mapping: Optional[Dict[int, int]] = None,
+        increase_position_ids_per_record: bool = False,
         # other parameters
         use_encoder_mlp: bool = True,
         use_constraints_encoder_mlp: bool = False,
-        decoder_position_id_mode: Optional[str] = None,
-        decoder_position_id_pattern: Optional[List[int]] = None,
-        increase_position_ids_per_record: bool = False,
         # optimizer
         lr: float = 5e-5,
         weight_decay: float = 1e-2,
@@ -70,6 +72,7 @@ class BartAsPointerNetworkConfig(BartConfig):
 
         self.decoder_position_id_mode = decoder_position_id_mode
         self.decoder_position_id_pattern = decoder_position_id_pattern
+        self.decoder_position_id_mapping = decoder_position_id_mapping
         self.increase_position_ids_per_record = increase_position_ids_per_record
 
         self.lr = lr
@@ -114,6 +117,7 @@ class BartAsPointerNetwork(BartPreTrainedModel):
             use_constraints_encoder_mlp=self.model.config.use_constraints_encoder_mlp,
             decoder_position_id_mode=self.model.config.decoder_position_id_mode,
             decoder_position_id_pattern=self.model.config.decoder_position_id_pattern,
+            decoder_position_id_mapping=self.model.config.decoder_position_id_mapping,
             increase_position_ids_per_record=self.model.config.increase_position_ids_per_record,
         )
 

--- a/src/pie_modules/models/base_models/bart_as_pointer_network.py
+++ b/src/pie_modules/models/base_models/bart_as_pointer_network.py
@@ -336,9 +336,7 @@ class BartAsPointerNetwork(BartPreTrainedModel):
             # we need to prepare the position ids for the decoder here, because later we do not have the full
             # input_ids anymore
             result["decoder_position_ids"] = self.pointer_head.prepare_decoder_position_ids(
-                input_ids=decoder_input_ids,
-                # the input_ids are in the target space, so we provide pointer_head.pad_id as the pad_token_id
-                pad_input_id=self.pointer_head.pad_id,
+                input_ids=decoder_input_ids
             )
 
         # cut decoder_input_ids if past_key_values is used

--- a/src/pie_modules/models/base_models/bart_as_pointer_network.py
+++ b/src/pie_modules/models/base_models/bart_as_pointer_network.py
@@ -46,6 +46,7 @@ class BartAsPointerNetworkConfig(BartConfig):
         # other parameters
         use_encoder_mlp: bool = True,
         use_constraints_encoder_mlp: bool = False,
+        decoder_position_id_mode: Optional[str] = None,
         decoder_position_id_pattern: Optional[List[int]] = None,
         increase_position_ids_per_record: bool = False,
         # optimizer
@@ -67,6 +68,7 @@ class BartAsPointerNetworkConfig(BartConfig):
         self.use_encoder_mlp = use_encoder_mlp
         self.use_constraints_encoder_mlp = use_constraints_encoder_mlp
 
+        self.decoder_position_id_mode = decoder_position_id_mode
         self.decoder_position_id_pattern = decoder_position_id_pattern
         self.increase_position_ids_per_record = increase_position_ids_per_record
 
@@ -88,7 +90,11 @@ class BartAsPointerNetwork(BartPreTrainedModel):
 
     def __init__(self, config: BartAsPointerNetworkConfig):
         super().__init__(config)
-        if self.config.decoder_position_id_pattern is not None:
+        # TODO: remove "or self.config.decoder_position_id_pattern is not None" when backward compatibility is removed
+        if (
+            self.config.decoder_position_id_mode is not None
+            or self.config.decoder_position_id_pattern is not None
+        ):
             self.model = BartModelWithDecoderPositionIds(config)
         else:
             self.model = BartModel(config)
@@ -106,6 +112,7 @@ class BartAsPointerNetwork(BartPreTrainedModel):
             # other parameters
             use_encoder_mlp=self.model.config.use_encoder_mlp,
             use_constraints_encoder_mlp=self.model.config.use_constraints_encoder_mlp,
+            decoder_position_id_mode=self.model.config.decoder_position_id_mode,
             decoder_position_id_pattern=self.model.config.decoder_position_id_pattern,
             increase_position_ids_per_record=self.model.config.increase_position_ids_per_record,
         )

--- a/src/pie_modules/models/components/pointer_head.py
+++ b/src/pie_modules/models/components/pointer_head.py
@@ -209,7 +209,7 @@ class PointerHead(torch.nn.Module):
             mapping: Dict[str, int] = self.decoder_position_id_mapping  # type: ignore
             if "default" not in mapping:
                 raise ValueError(
-                    f"mapping must contain a default entry, but only contains {mapping.keys()}!"
+                    f"mapping must contain a default entry, but only contains {list(mapping)}!"
                 )
             position_ids = input_ids.new_full(input_ids.size(), fill_value=mapping["default"])
             for key, value in mapping.items():
@@ -224,7 +224,7 @@ class PointerHead(torch.nn.Module):
                 elif key == "pad":
                     position_ids[input_ids.eq(self.pad_id)] = value
                 else:
-                    raise ValueError(f'Unknown key "{key}" for mapping {mapping}!')
+                    raise ValueError(f"Mapping contains unknown key '{key}' (mapping: {mapping}).")
             return position_ids
         else:
             raise ValueError(

--- a/tests/models/components/test_pointer_head.py
+++ b/tests/models/components/test_pointer_head.py
@@ -182,6 +182,27 @@ def test_prepare_decoder_position_ids(decoder_position_id_mode):
         raise ValueError(f"unknown decoder_position_id_mode={decoder_position_id_mode}")
 
 
+@pytest.mark.parametrize(
+    "decoder_position_id_mode",
+    ["pattern", "pattern_with_increment", "mapping"],
+)
+def test_prepare_decoder_position_ids_missing_parameter(decoder_position_id_mode):
+    with pytest.raises(ValueError) as excinfo:
+        get_pointer_head(decoder_position_id_mode=decoder_position_id_mode)
+    if decoder_position_id_mode in ["pattern", "pattern_with_increment"]:
+        assert (
+            str(excinfo.value) == "decoder_position_id_pattern must be provided when using "
+            'decoder_position_id_mode="pattern" or "pattern_with_increment"!'
+        )
+    elif decoder_position_id_mode == "mapping":
+        assert (
+            str(excinfo.value)
+            == 'decoder_position_id_mode="mapping" requires decoder_position_id_mapping to be provided!'
+        )
+    else:
+        raise ValueError(f"unknown decoder_position_id_mode={decoder_position_id_mode}")
+
+
 def test_prepare_decoder_position_ids_with_wrong_mapping():
     input_ids = torch.tensor(
         [

--- a/tests/models/components/test_pointer_head.py
+++ b/tests/models/components/test_pointer_head.py
@@ -158,11 +158,7 @@ def test_prepare_decoder_position_ids(decoder_position_id_mode):
         ]
     ).to(torch.long)
 
-    prepared_decoder_position_ids = pointer_head.prepare_decoder_position_ids(
-        input_ids=input_ids,
-        # the input_ids are in the target space, so we provide pointer_head.pad_id as the pad_token_id
-        pad_input_id=pointer_head.pad_id,
-    )
+    prepared_decoder_position_ids = pointer_head.prepare_decoder_position_ids(input_ids=input_ids)
     assert prepared_decoder_position_ids is not None
     assert prepared_decoder_position_ids.shape == input_ids.shape
     if decoder_position_id_mode == "pattern":

--- a/tests/models/components/test_pointer_head.py
+++ b/tests/models/components/test_pointer_head.py
@@ -137,13 +137,16 @@ def test_prepare_decoder_input_ids_out_of_bounds():
 
 @pytest.mark.parametrize(
     "decoder_position_id_mode",
-    ["pattern", "pattern_with_increment", "mapping_default:3-labels:2-bos:0-eos:0-pad:1"],
+    ["pattern", "pattern_with_increment", "mapping"],
 )
 def test_prepare_decoder_position_ids(decoder_position_id_mode):
     pointer_head = get_pointer_head(
         decoder_position_id_mode=decoder_position_id_mode,
         decoder_position_id_pattern=[0, 1, 1, 2]
         if "pattern" in decoder_position_id_mode
+        else None,
+        decoder_position_id_mapping={"default": 3, "vocab": 2, "bos": 0, "eos": 0, "pad": 1}
+        if decoder_position_id_mode == "mapping"
         else None,
     )
     input_ids = torch.tensor(
@@ -174,7 +177,7 @@ def test_prepare_decoder_position_ids(decoder_position_id_mode):
             [0, 2, 3, 3, 4, 5],
             [0, 2, 3, 3, 1, 1],
         ]
-    elif decoder_position_id_mode == "mapping_default:3-labels:2-bos:0-eos:0-pad:1":
+    elif decoder_position_id_mode == "mapping":
         assert prepared_decoder_position_ids.tolist() == [
             [0, 3, 3, 2, 2, 3],
             [0, 2, 3, 0, 1, 1],


### PR DESCRIPTION
This PR adds two more parameter, `decoder_position_id_mode` and `decoder_position_id_mapping`, to the `PointerHead` as well as to the `BartAsPointerNetwork` that allow for more control how the `position_ids` are created. The former defines  the general approach how to create position_ids and accepts one of the following values:
 - `pattern`: requires a `decoder_position_id_pattern` that will be used to have a fixed pattern for all "records", e.g. `[0,0,1,0,0,1,1]` defines that all indices (positions 0, 1, 3, 4) and all labels (positions 2, 5, 6) get the same position id. This is as if previously just `decoder_position_id_pattern` was defined and, in fact, the way how the authors of [A Generative Model for End-to-End Argument Mining with Reconstructed Positional Encoding and Constrained Pointer Mechanism](https://aclanthology.org/2022.emnlp-main.713) (Bao et al., EMNLP 2022) proposed it. Note, that the bos and pad token get special ids different then the ones defined via the pattern. 
 - `pattern_with_increment`: As above, but ids are incremented record-wise, e.g when sticking to the example above, the first record will be using the pattern `[0,0,1,0,0,1,1]`, the second would get `[2,2,3,2,2,3,3]` and so on.
 - `mapping`: requires a `decoder_position_id_mapping` which is a `Dict[str, int]` that defines how the position ids are created for certain input ids. It can have the following keys:
   - `default` (**required**): the position ids are initialized with this value
   - `vocab`: the position ids for all input ids below `pointer_offset`, i.e. everything that is not an index, gets this value
   - `bos`, `eos`, or `pad`: the position ids for bos, eos, or pad input ids, respectively, get this value (overwrites the respective values if they are already set via `vocab`)

Note: This also simplifies `PointerHead.prepare_decoder_position_ids()` a bit by removing its parameter `pad_input_id`. This was set to `pointer_head.pad_id` in each case that method was called, so we use `self.pad_id` directly.