### PR TITLE
add span utils

### DIFF
--- a/src/pie_modules/utils/span.py
+++ b/src/pie_modules/utils/span.py
@@ -9,6 +9,12 @@ def have_overlap(start_end: Tuple[int, int], other_start_end: Tuple[int, int]) -
     return other_start_overlaps or other_end_overlaps or start_overlaps_other or end_overlaps_other
 
 
+def are_nested(start_end: Tuple[int, int], other_start_end: Tuple[int, int]) -> bool:
+    return (start_end[0] <= other_start_end[0] and start_end[1] >= other_start_end[1]) or (
+        other_start_end[0] <= start_end[0] and other_start_end[1] >= start_end[1]
+    )
+
+
 def distance_center(start_end: Tuple[int, int], other_start_end: Tuple[int, int]) -> float:
     center = (start_end[0] + start_end[1]) / 2
     center_other = (other_start_end[0] + other_start_end[1]) / 2

--- a/src/pie_modules/utils/span.py
+++ b/src/pie_modules/utils/span.py
@@ -1,26 +1,12 @@
 from typing import Tuple
 
 
-def get_overlap_len(start_end: Tuple[int, int], other_start_end: Tuple[int, int]) -> int:
-    if start_end[0] > other_start_end[0]:
-        tmp = start_end
-        start_end = other_start_end
-        other_start_end = tmp
-    if start_end[1] <= other_start_end[0]:
-        return 0
-    return min(start_end[1] - other_start_end[0], other_start_end[1] - other_start_end[0])
-
-
 def have_overlap(start_end: Tuple[int, int], other_start_end: Tuple[int, int]) -> bool:
     other_start_overlaps = start_end[0] <= other_start_end[0] < start_end[1]
     other_end_overlaps = start_end[0] < other_start_end[1] <= start_end[1]
     start_overlaps_other = other_start_end[0] <= start_end[0] < other_start_end[1]
     end_overlaps_other = other_start_end[0] < start_end[1] <= other_start_end[1]
     return other_start_overlaps or other_end_overlaps or start_overlaps_other or end_overlaps_other
-
-
-def is_contained_in(start_end: Tuple[int, int], other_start_end: Tuple[int, int]) -> bool:
-    return other_start_end[0] <= start_end[0] and start_end[1] <= other_start_end[1]
 
 
 def distance_center(start_end: Tuple[int, int], other_start_end: Tuple[int, int]) -> float:

--- a/src/pie_modules/utils/span.py
+++ b/src/pie_modules/utils/span.py
@@ -2,6 +2,12 @@ from typing import Tuple
 
 
 def have_overlap(start_end: Tuple[int, int], other_start_end: Tuple[int, int]) -> bool:
+    """Check if two spans have an overlap. The spans are defined by their start and end indices.
+
+    Note that two spans that are touching each other are not considered to have an overlap. But two
+    spans that are identical are considered to have an overlap.
+    """
+
     other_start_overlaps = start_end[0] <= other_start_end[0] < start_end[1]
     other_end_overlaps = start_end[0] < other_start_end[1] <= start_end[1]
     start_overlaps_other = other_start_end[0] <= start_end[0] < other_start_end[1]
@@ -10,24 +16,43 @@ def have_overlap(start_end: Tuple[int, int], other_start_end: Tuple[int, int]) -
 
 
 def are_nested(start_end: Tuple[int, int], other_start_end: Tuple[int, int]) -> bool:
+    """Check if two spans are nested. The spans are defined by their start and end indices.
+
+    Note that spans are considered to be nested if one is completely contained in the other,
+    including the case where they are identical.
+    """
     return (start_end[0] <= other_start_end[0] and start_end[1] >= other_start_end[1]) or (
         other_start_end[0] <= start_end[0] and other_start_end[1] >= start_end[1]
     )
 
 
 def distance_center(start_end: Tuple[int, int], other_start_end: Tuple[int, int]) -> float:
+    """Calculate the distance between the centers of two spans.
+
+    The spans are defined by their start and end indices.
+    """
     center = (start_end[0] + start_end[1]) / 2
     center_other = (other_start_end[0] + other_start_end[1]) / 2
     return abs(center - center_other)
 
 
 def distance_outer(start_end: Tuple[int, int], other_start_end: Tuple[int, int]) -> float:
+    """Calculate the distance between the outer edges of two spans. The spans are defined by their
+    start and end indices.
+
+    In case of an overlap, the covered area is considered to be the distance.
+    """
     _max = max(start_end[0], start_end[1], other_start_end[0], other_start_end[1])
     _min = min(start_end[0], start_end[1], other_start_end[0], other_start_end[1])
     return float(_max - _min)
 
 
 def distance_inner(start_end: Tuple[int, int], other_start_end: Tuple[int, int]) -> float:
+    """Calculate the distance between the inner edges of two spans.The spans are defined by their
+    start and end indices.
+
+    In case of an overlap, the negative of the overlapping area is considered to be the distance.
+    """
     dist_start_other_end = abs(start_end[0] - other_start_end[1])
     dist_end_other_start = abs(start_end[1] - other_start_end[0])
     dist = float(min(dist_start_other_end, dist_end_other_start))
@@ -40,6 +65,13 @@ def distance_inner(start_end: Tuple[int, int], other_start_end: Tuple[int, int])
 def distance(
     start_end: Tuple[int, int], other_start_end: Tuple[int, int], distance_type: str
 ) -> float:
+    """Calculate the distance between two spans.
+
+    Args:
+        start_end: a tuple of two integers representing the start and end index of the first span
+        other_start_end: a tuple of two integers representing the start and end index of the second span
+        distance_type: the type of distance to calculate. One of: center, inner, outer
+    """
     if distance_type == "center":
         return distance_center(start_end, other_start_end)
     elif distance_type == "inner":

--- a/src/pie_modules/utils/span.py
+++ b/src/pie_modules/utils/span.py
@@ -48,7 +48,7 @@ def distance_outer(start_end: Tuple[int, int], other_start_end: Tuple[int, int])
 
 
 def distance_inner(start_end: Tuple[int, int], other_start_end: Tuple[int, int]) -> float:
-    """Calculate the distance between the inner edges of two spans.The spans are defined by their
+    """Calculate the distance between the inner edges of two spans. The spans are defined by their
     start and end indices.
 
     In case of an overlap, the negative of the overlapping area is considered to be the distance.
@@ -65,7 +65,7 @@ def distance_inner(start_end: Tuple[int, int], other_start_end: Tuple[int, int])
 def distance(
     start_end: Tuple[int, int], other_start_end: Tuple[int, int], distance_type: str
 ) -> float:
-    """Calculate the distance between two spans.
+    """Calculate the distance between two spans based on the given distance type.
 
     Args:
         start_end: a tuple of two integers representing the start and end index of the first span

--- a/src/pie_modules/utils/span.py
+++ b/src/pie_modules/utils/span.py
@@ -1,20 +1,6 @@
 from typing import Tuple
 
 
-def have_overlap(start_end: Tuple[int, int], other_start_end: Tuple[int, int]) -> bool:
-    """Check if two spans have an overlap. The spans are defined by their start and end indices.
-
-    Note that two spans that are touching each other are not considered to have an overlap. But two
-    spans that are identical are considered to have an overlap.
-    """
-
-    other_start_overlaps = start_end[0] <= other_start_end[0] < start_end[1]
-    other_end_overlaps = start_end[0] < other_start_end[1] <= start_end[1]
-    start_overlaps_other = other_start_end[0] <= start_end[0] < other_start_end[1]
-    end_overlaps_other = other_start_end[0] < start_end[1] <= other_start_end[1]
-    return other_start_overlaps or other_end_overlaps or start_overlaps_other or end_overlaps_other
-
-
 def are_nested(start_end: Tuple[int, int], other_start_end: Tuple[int, int]) -> bool:
     """Check if two spans are nested. The spans are defined by their start and end indices.
 
@@ -24,6 +10,21 @@ def are_nested(start_end: Tuple[int, int], other_start_end: Tuple[int, int]) -> 
     return (start_end[0] <= other_start_end[0] and start_end[1] >= other_start_end[1]) or (
         other_start_end[0] <= start_end[0] and other_start_end[1] >= start_end[1]
     )
+
+
+def have_overlap(start_end: Tuple[int, int], other_start_end: Tuple[int, int]) -> bool:
+    """Check if two spans have an overlap. The spans are defined by their start and end indices.
+
+    Note that two spans that are touching each other are not considered to have an overlap. But two
+    spans that are nested, including the case where they are identical, are considered to have an
+    overlap.
+    """
+
+    other_start_overlaps = start_end[0] <= other_start_end[0] < start_end[1]
+    other_end_overlaps = start_end[0] < other_start_end[1] <= start_end[1]
+    start_overlaps_other = other_start_end[0] <= start_end[0] < other_start_end[1]
+    end_overlaps_other = other_start_end[0] < start_end[1] <= other_start_end[1]
+    return other_start_overlaps or other_end_overlaps or start_overlaps_other or end_overlaps_other
 
 
 def distance_center(start_end: Tuple[int, int], other_start_end: Tuple[int, int]) -> float:

--- a/src/pie_modules/utils/span.py
+++ b/src/pie_modules/utils/span.py
@@ -1,0 +1,60 @@
+from typing import Tuple
+
+
+def get_overlap_len(start_end: Tuple[int, int], other_start_end: Tuple[int, int]) -> int:
+    if start_end[0] > other_start_end[0]:
+        tmp = start_end
+        start_end = other_start_end
+        other_start_end = tmp
+    if start_end[1] <= other_start_end[0]:
+        return 0
+    return min(start_end[1] - other_start_end[0], other_start_end[1] - other_start_end[0])
+
+
+def have_overlap(start_end: Tuple[int, int], other_start_end: Tuple[int, int]) -> bool:
+    other_start_overlaps = start_end[0] <= other_start_end[0] < start_end[1]
+    other_end_overlaps = start_end[0] < other_start_end[1] <= start_end[1]
+    start_overlaps_other = other_start_end[0] <= start_end[0] < other_start_end[1]
+    end_overlaps_other = other_start_end[0] < start_end[1] <= other_start_end[1]
+    return other_start_overlaps or other_end_overlaps or start_overlaps_other or end_overlaps_other
+
+
+def is_contained_in(start_end: Tuple[int, int], other_start_end: Tuple[int, int]) -> bool:
+    return other_start_end[0] <= start_end[0] and start_end[1] <= other_start_end[1]
+
+
+def distance_center(start_end: Tuple[int, int], other_start_end: Tuple[int, int]) -> float:
+    center = (start_end[0] + start_end[1]) / 2
+    center_other = (other_start_end[0] + other_start_end[1]) / 2
+    return abs(center - center_other)
+
+
+def distance_outer(start_end: Tuple[int, int], other_start_end: Tuple[int, int]) -> float:
+    _max = max(start_end[0], start_end[1], other_start_end[0], other_start_end[1])
+    _min = min(start_end[0], start_end[1], other_start_end[0], other_start_end[1])
+    return float(_max - _min)
+
+
+def distance_inner(start_end: Tuple[int, int], other_start_end: Tuple[int, int]) -> float:
+    dist_start_other_end = abs(start_end[0] - other_start_end[1])
+    dist_end_other_start = abs(start_end[1] - other_start_end[0])
+    dist = float(min(dist_start_other_end, dist_end_other_start))
+    if not have_overlap(start_end, other_start_end):
+        return dist
+    else:
+        return -dist
+
+
+def distance(
+    start_end: Tuple[int, int], other_start_end: Tuple[int, int], distance_type: str
+) -> float:
+    if distance_type == "center":
+        return distance_center(start_end, other_start_end)
+    elif distance_type == "inner":
+        return distance_inner(start_end, other_start_end)
+    elif distance_type == "outer":
+        return distance_outer(start_end, other_start_end)
+    else:
+        raise ValueError(
+            f"unknown distance_type={distance_type}. use one of: center, inner, outer"
+        )

--- a/tests/utils/test_span.py
+++ b/tests/utils/test_span.py
@@ -1,0 +1,14 @@
+import pytest
+
+from pie_modules.utils.span import distance, distance_inner
+
+
+def test_inner_span_distance_overlap():
+    dist = distance_inner((0, 2), (1, 3))
+    assert dist == -1
+
+
+def test_span_distance_unknown_type():
+    with pytest.raises(ValueError) as excinfo:
+        distance((0, 1), (2, 3), "unknown")
+    assert str(excinfo.value) == "unknown distance_type=unknown. use one of: inner"

--- a/tests/utils/test_span.py
+++ b/tests/utils/test_span.py
@@ -1,6 +1,7 @@
 import pytest
 
 from pie_modules.utils.span import (
+    are_nested,
     distance,
     distance_center,
     distance_inner,
@@ -27,6 +28,29 @@ def test_have_overlap():
     assert have_overlap((1, 2), (0, 2))
     # overlap, identical
     assert have_overlap((0, 1), (0, 1))
+
+
+def test_are_nested():
+    # no overlap, not touching
+    assert not are_nested((0, 1), (2, 3))
+    assert not are_nested((2, 3), (0, 1))
+    # no overlap, touching
+    assert not are_nested((0, 1), (1, 2))
+    assert not are_nested((1, 2), (0, 1))
+    # overlap, not touching
+    assert not are_nested((0, 2), (1, 3))
+    assert not are_nested((1, 3), (0, 2))
+    # overlap, same start
+    assert are_nested((0, 2), (0, 3))
+    assert are_nested((0, 3), (0, 2))
+    # overlap, same end
+    assert are_nested((0, 2), (1, 2))
+    assert are_nested((1, 2), (0, 2))
+    # overlap, identical
+    assert are_nested((0, 1), (0, 1))
+    # nested, not touching
+    assert are_nested((0, 3), (1, 2))
+    assert are_nested((1, 2), (0, 3))
 
 
 def test_distance_center():

--- a/tests/utils/test_span.py
+++ b/tests/utils/test_span.py
@@ -11,4 +11,4 @@ def test_inner_span_distance_overlap():
 def test_span_distance_unknown_type():
     with pytest.raises(ValueError) as excinfo:
         distance((0, 1), (2, 3), "unknown")
-    assert str(excinfo.value) == "unknown distance_type=unknown. use one of: inner"
+    assert str(excinfo.value) == "unknown distance_type=unknown. use one of: center, inner, outer"

--- a/tests/utils/test_span.py
+++ b/tests/utils/test_span.py
@@ -3,12 +3,12 @@ import pytest
 from pie_modules.utils.span import distance, distance_inner
 
 
-def test_inner_span_distance_overlap():
+def test_distance_inner_overlap():
     dist = distance_inner((0, 2), (1, 3))
     assert dist == -1
 
 
-def test_span_distance_unknown_type():
+def test_distance_unknown_type():
     with pytest.raises(ValueError) as excinfo:
         distance((0, 1), (2, 3), "unknown")
     assert str(excinfo.value) == "unknown distance_type=unknown. use one of: center, inner, outer"

--- a/tests/utils/test_span.py
+++ b/tests/utils/test_span.py
@@ -25,6 +25,8 @@ def test_have_overlap():
     # overlap, same end
     assert have_overlap((0, 2), (1, 2))
     assert have_overlap((1, 2), (0, 2))
+    # overlap, identical
+    assert have_overlap((0, 1), (0, 1))
 
 
 def test_distance_center():
@@ -43,6 +45,8 @@ def test_distance_center():
     # overlap, same end
     assert distance_center((0, 2), (1, 2)) == 0.5
     assert distance_center((1, 2), (0, 2)) == 0.5
+    # overlap, identical
+    assert distance_center((0, 1), (0, 1)) == 0.0
 
 
 def test_distance_inner():
@@ -61,9 +65,13 @@ def test_distance_inner():
     # overlap, same end
     assert distance_inner((0, 2), (1, 2)) == -1.0
     assert distance_inner((1, 2), (0, 2)) == -1.0
+    # overlap, identical
+    assert distance_inner((0, 1), (0, 1)) == -1.0
 
 
 def test_distance_outer():
+    # identical
+    assert distance_outer((0, 1), (0, 1)) == 1.0
     # no overlap, not touching
     assert distance_outer((0, 1), (2, 3)) == 3.0
     assert distance_outer((2, 3), (0, 1)) == 3.0

--- a/tests/utils/test_span.py
+++ b/tests/utils/test_span.py
@@ -5,7 +5,26 @@ from pie_modules.utils.span import (
     distance_center,
     distance_inner,
     distance_outer,
+    have_overlap,
 )
+
+
+def test_have_overlap():
+    # no overlap, not touching
+    assert not have_overlap((0, 1), (2, 3))
+    assert not have_overlap((2, 3), (0, 1))
+    # no overlap, touching
+    assert not have_overlap((0, 1), (1, 2))
+    assert not have_overlap((1, 2), (0, 1))
+    # overlap, not touching
+    assert have_overlap((0, 2), (1, 3))
+    assert have_overlap((1, 3), (0, 2))
+    # overlap, same start
+    assert have_overlap((0, 2), (0, 3))
+    assert have_overlap((0, 3), (0, 2))
+    # overlap, same end
+    assert have_overlap((0, 2), (1, 2))
+    assert have_overlap((1, 2), (0, 2))
 
 
 def test_distance_center():

--- a/tests/utils/test_span.py
+++ b/tests/utils/test_span.py
@@ -1,14 +1,79 @@
 import pytest
 
-from pie_modules.utils.span import distance, distance_inner
+from pie_modules.utils.span import (
+    distance,
+    distance_center,
+    distance_inner,
+    distance_outer,
+)
 
 
-def test_distance_inner_overlap():
-    dist = distance_inner((0, 2), (1, 3))
-    assert dist == -1
+def test_distance_center():
+    # no overlap, not touching
+    assert distance_center((0, 1), (2, 3)) == 2.0
+    assert distance_center((2, 3), (0, 1)) == 2.0
+    # no overlap, touching
+    assert distance_center((0, 1), (1, 2)) == 1.0
+    assert distance_center((1, 2), (0, 1)) == 1.0
+    # overlap, not touching
+    assert distance_center((0, 2), (1, 3)) == 1.0
+    assert distance_center((1, 3), (0, 2)) == 1.0
+    # overlap, same start
+    assert distance_center((0, 2), (0, 3)) == 0.5
+    assert distance_center((0, 3), (0, 2)) == 0.5
+    # overlap, same end
+    assert distance_center((0, 2), (1, 2)) == 0.5
+    assert distance_center((1, 2), (0, 2)) == 0.5
 
 
-def test_distance_unknown_type():
-    with pytest.raises(ValueError) as excinfo:
-        distance((0, 1), (2, 3), "unknown")
-    assert str(excinfo.value) == "unknown distance_type=unknown. use one of: center, inner, outer"
+def test_distance_inner():
+    # no overlap, not touching
+    assert distance_inner((0, 1), (2, 3)) == 1.0
+    assert distance_inner((2, 3), (0, 1)) == 1.0
+    # no overlap, touching
+    assert distance_inner((0, 1), (1, 2)) == 0.0
+    assert distance_inner((1, 2), (0, 1)) == 0.0
+    # overlap, not touching
+    assert distance_inner((0, 2), (1, 3)) == -1.0
+    assert distance_inner((1, 3), (0, 2)) == -1.0
+    # overlap, same start
+    assert distance_inner((0, 2), (0, 3)) == -2.0
+    assert distance_inner((0, 3), (0, 2)) == -2.0
+    # overlap, same end
+    assert distance_inner((0, 2), (1, 2)) == -1.0
+    assert distance_inner((1, 2), (0, 2)) == -1.0
+
+
+def test_distance_outer():
+    # no overlap, not touching
+    assert distance_outer((0, 1), (2, 3)) == 3.0
+    assert distance_outer((2, 3), (0, 1)) == 3.0
+    # no overlap, touching
+    assert distance_outer((0, 1), (1, 2)) == 2.0
+    assert distance_outer((1, 2), (0, 1)) == 2.0
+    # overlap, not touching
+    assert distance_outer((0, 2), (1, 3)) == 3.0
+    assert distance_outer((1, 3), (0, 2)) == 3.0
+    # overlap, same start
+    assert distance_outer((0, 2), (0, 3)) == 3.0
+    assert distance_outer((0, 3), (0, 2)) == 3.0
+    # overlap, same end
+    assert distance_outer((0, 2), (1, 2)) == 2.0
+    assert distance_outer((1, 2), (0, 2)) == 2.0
+
+
+@pytest.mark.parametrize(
+    "distance_type",
+    ["outer", "center", "inner", "unknown"],
+)
+def test_distance(distance_type):
+    start_end = (0, 1)
+    other_start_end = (2, 3)
+    if distance_type != "unknown":
+        distance(start_end, other_start_end, distance_type)
+    else:
+        with pytest.raises(ValueError) as excinfo:
+            distance(start_end, other_start_end, distance_type)
+        assert (
+            str(excinfo.value) == "unknown distance_type=unknown. use one of: center, inner, outer"
+        )


### PR DESCRIPTION
with the following methods:
 - `are_nested`: Check if two spans are nested. Note that spans are considered to be nested if one is completely contained in the other, including the case where they are identical.
 - `have_overlap`: Check if two spans have an overlap. Note that two spans that are touching each other are not considered to have an overlap. But two spans that are nested, including the case where they are identical, are considered to have an overlap.
 - `distance_center`: Calculate the distance between the centers of two spans. The spans are defined by their start and end indices.
 - `distance_inner`: Calculate the distance between the inner edges of two spans. In case of an overlap, the negative of the overlapping area is considered to be the distance.
 - `distance_outer`: Calculate the distance between the outer edges of two spans. In case of an overlap, the covered area is considered to be the distance.
 - `distance`: Calculate the distance between two spans based on the given distance type.

This requires #69.