### PR TITLE
add `RelationArgumentDistanceCollector` statistic

### DIFF
--- a/src/pie_modules/metrics/__init__.py
+++ b/src/pie_modules/metrics/__init__.py
@@ -6,6 +6,7 @@ from pytorch_ie.metrics.statistics import (
     TokenCountCollector,
 )
 
+from .relation_argument_distance_collector import RelationArgumentDistanceCollector
 from .span_coverage_collector import SpanCoverageCollector
 from .span_length_collector import SpanLengthCollector
 from .squad_f1 import SQuADF1

--- a/src/pie_modules/metrics/relation_argument_distance_collector.py
+++ b/src/pie_modules/metrics/relation_argument_distance_collector.py
@@ -1,0 +1,118 @@
+from collections import defaultdict
+from typing import Any, Dict, List, Optional, Type, Union
+
+from pytorch_ie.annotations import BinaryRelation, NaryRelation, Span
+from pytorch_ie.core import Document, DocumentStatistic
+from pytorch_ie.documents import TextBasedDocument, TokenBasedDocument
+from pytorch_ie.utils.hydra import resolve_target
+from src.utils.span import distance
+from transformers import AutoTokenizer, PreTrainedTokenizer
+
+from pie_modules.document.processing import tokenize_document
+
+
+class RelationArgumentDistanceCollector(DocumentStatistic):
+    """Collects the distances between the arguments of binary relations. For n-ary relations, the
+    distances between all pairs of arguments are collected.
+
+    If a tokenizer is provided, the distance is calculated in means of tokens, otherwise in means
+    of characters.
+    """
+
+    DEFAULT_AGGREGATION_FUNCTIONS = ["len", "mean", "std", "min", "max"]
+
+    def __init__(
+        self,
+        layer: str,
+        distance_type: str = "outer",
+        tokenize: bool = False,
+        tokenize_kwargs: Optional[Dict[str, Any]] = None,
+        tokenizer: Optional[Union[str, PreTrainedTokenizer]] = None,
+        tokenized_document_type: Optional[Union[str, Type[TokenBasedDocument]]] = None,
+        key_all: str = "ALL",
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self.layer = layer
+        self.distance_type = distance_type
+        self.key_all = key_all
+        self.tokenize = tokenize
+        self.tokenize_kwargs = tokenize_kwargs or {}
+        if self.tokenize:
+            if tokenizer is None:
+                raise ValueError(
+                    "tokenizer must be provided to calculate distance in means of tokens"
+                )
+            if isinstance(tokenizer, str):
+                tokenizer = AutoTokenizer.from_pretrained(tokenizer)
+            self.tokenizer = tokenizer
+            if tokenized_document_type is None:
+                raise ValueError(
+                    "tokenized_document_type must be provided to calculate distance in means of tokens"
+                )
+            self.tokenized_document_type: Type[TokenBasedDocument] = resolve_target(
+                tokenized_document_type
+            )
+
+    def _collect(self, doc: Document) -> Dict[str, List[float]]:
+        if self.tokenize:
+            if not isinstance(doc, TextBasedDocument):
+                raise ValueError(
+                    "doc must be a TextBasedDocument to calculate distance in means of tokens"
+                )
+            if not isinstance(doc, TextBasedDocument):
+                raise ValueError(
+                    "doc must be a TextBasedDocument to calculate distance in means of tokens"
+                )
+            docs = tokenize_document(
+                doc,
+                tokenizer=self.tokenizer,
+                result_document_type=self.tokenized_document_type,
+                **self.tokenize_kwargs,
+            )
+        else:
+            docs = [doc]
+        values: Dict[str, List[float]] = defaultdict(list)
+        for doc in docs:
+            layer_obj = getattr(doc, self.layer)
+
+            for binary_relation in layer_obj:
+                if isinstance(binary_relation, BinaryRelation):
+                    args = [binary_relation.head, binary_relation.tail]
+                    label = binary_relation.label
+                elif isinstance(binary_relation, NaryRelation):
+                    args = binary_relation.arguments
+                    label = binary_relation.label
+                else:
+                    raise TypeError(
+                        f"argument distance calculation is not yet supported for {type(binary_relation)}"
+                    )
+                if any(not isinstance(arg, Span) for arg in args):
+                    raise TypeError(
+                        "argument distance calculation is not yet supported for arguments other than Spans"
+                    )
+                # collect distances between all pairs of arguments
+                for idx1, arg1 in enumerate(args):
+                    for idx2, arg2 in enumerate(args):
+                        if idx1 == idx2:
+                            continue
+                        d = distance(
+                            start_end=(arg1.start, arg1.end),
+                            other_start_end=(arg2.start, arg2.end),
+                            distance_type=self.distance_type,
+                        )
+
+                        values[label].append(d)
+
+        if self.key_all in values:
+            raise ValueError(
+                f'key key_all="{self.key_all}" is reserved for the aggregation of all values. Please '
+                f"choose another value for key_all which is not used as a label of any annotation."
+            )
+        labels = list(values)
+        for label in labels:
+            values[self.key_all].extend(values[label])
+
+        # improve order of entries for histogram plotting: first, the key_all entry, then the rest,
+        # so that not the key_all entry is plotted last and thus covers all other entries
+        return {label: values[label] for label in [self.key_all] + labels}

--- a/src/pie_modules/metrics/relation_argument_distance_collector.py
+++ b/src/pie_modules/metrics/relation_argument_distance_collector.py
@@ -5,10 +5,10 @@ from pytorch_ie.annotations import BinaryRelation, NaryRelation, Span
 from pytorch_ie.core import Document, DocumentStatistic
 from pytorch_ie.documents import TextBasedDocument, TokenBasedDocument
 from pytorch_ie.utils.hydra import resolve_target
-from src.utils.span import distance
 from transformers import AutoTokenizer, PreTrainedTokenizer
 
 from pie_modules.document.processing import tokenize_document
+from pie_modules.utils.span import distance
 
 
 class RelationArgumentDistanceCollector(DocumentStatistic):

--- a/src/pie_modules/metrics/relation_argument_distance_collector.py
+++ b/src/pie_modules/metrics/relation_argument_distance_collector.py
@@ -12,11 +12,19 @@ from pie_modules.utils.span import distance
 
 
 class RelationArgumentDistanceCollector(DocumentStatistic):
-    """Collects the distances between the arguments of binary relations. For n-ary relations, the
-    distances between all pairs of arguments are collected.
+    """Collects the distances between the arguments of relation annotations. For n-ary relations,
+    the distances between all pairs of arguments are collected. The distances can be calculated in
+    means of characters or tokens.
 
-    If a tokenizer is provided, the distance is calculated in means of tokens, otherwise in means
-    of characters.
+    Args:
+        layer: The relation annotation layer of the document to collect the distances from.
+        distance_type: The type of distance to calculate. Can be "outer", "inner", or "center".
+        tokenize: Whether to tokenize the document before calculating the distance.
+        tokenizer: The tokenizer to use for tokenization. If a string is provided, the tokenizer is
+            loaded from the Hugging Face model hub. Required if tokenize is True.
+        tokenized_document_type: The type of document to return after tokenization. Required if
+            tokenize is True.
+        key_all: The key to use for the aggregation of all values.
     """
 
     DEFAULT_AGGREGATION_FUNCTIONS = ["len", "mean", "std", "min", "max"]

--- a/src/pie_modules/metrics/relation_argument_distance_collector.py
+++ b/src/pie_modules/metrics/relation_argument_distance_collector.py
@@ -68,10 +68,6 @@ class RelationArgumentDistanceCollector(DocumentStatistic):
                 raise ValueError(
                     "doc must be a TextBasedDocument to calculate distance in means of tokens"
                 )
-            if not isinstance(doc, TextBasedDocument):
-                raise ValueError(
-                    "doc must be a TextBasedDocument to calculate distance in means of tokens"
-                )
             docs = tokenize_document(
                 doc,
                 tokenizer=self.tokenizer,

--- a/tests/metrics/test_relation_argument_distance_collector.py
+++ b/tests/metrics/test_relation_argument_distance_collector.py
@@ -1,0 +1,238 @@
+import dataclasses
+
+import pytest
+from pytorch_ie import Annotation, Document
+from pytorch_ie.annotations import (
+    BinaryRelation,
+    LabeledSpan,
+    MultiLabeledBinaryRelation,
+)
+from pytorch_ie.core import AnnotationList, annotation_field
+from pytorch_ie.documents import TextBasedDocument, TokenBasedDocument
+
+from pie_modules.annotations import LabeledMultiSpan
+from pie_modules.metrics import RelationArgumentDistanceCollector
+
+
+@dataclasses.dataclass
+class TestDocument(TextBasedDocument):
+    entities: AnnotationList[LabeledSpan] = annotation_field(target="text")
+    relations: AnnotationList[BinaryRelation] = annotation_field(target="entities")
+
+
+def test_relation_argument_distance_collector():
+    doc = TestDocument(
+        text="This is the first entity. This is the second entity. " "This is the third entity."
+    )
+    doc.entities.append(LabeledSpan(start=0, end=25, label="entity"))
+    doc.entities.append(LabeledSpan(start=26, end=52, label="entity"))
+    doc.entities.append(LabeledSpan(start=53, end=78, label="entity"))
+    doc.relations.append(
+        BinaryRelation(head=doc.entities[0], tail=doc.entities[1], label="relation_label_1")
+    )
+    doc.relations.append(
+        BinaryRelation(head=doc.entities[1], tail=doc.entities[2], label="relation_label_2")
+    )
+
+    statistic = RelationArgumentDistanceCollector(layer="relations")
+    values = statistic(doc)
+    assert values == {
+        "ALL": {"len": 4, "mean": 52.0, "std": 0.0, "min": 52.0, "max": 52.0},
+        "relation_label_1": {"len": 2, "mean": 52.0, "std": 0.0, "min": 52.0, "max": 52.0},
+        "relation_label_2": {"len": 2, "mean": 52.0, "std": 0.0, "min": 52.0, "max": 52.0},
+    }
+
+
+def test_relation_argument_distance_collector_with_multi_span():
+    doc = TestDocument(
+        text="This is the first entity. This is the second entity. "
+        "This is a filler. This is the third entity."
+    )
+    doc.entities.append(LabeledMultiSpan(slices=((0, 25),), label="entity"))
+    doc.entities.append(LabeledMultiSpan(slices=((26, 52),), label="entity"))
+    doc.entities.append(LabeledMultiSpan(slices=((53, 78),), label="entity"))
+    doc.relations.append(
+        MultiLabeledBinaryRelation(
+            head=doc.entities[0], tail=doc.entities[1], label="relation_label_1"
+        )
+    )
+    doc.relations.append(
+        MultiLabeledBinaryRelation(
+            head=doc.entities[1], tail=doc.entities[2], label="relation_label_2"
+        )
+    )
+
+    # TypeError
+    # argument distance calculation is not yet supported for <class 'pytorch_ie.annotations.MultiLabeledBinaryRelation'>
+    statistic = RelationArgumentDistanceCollector(layer="relations")
+    values = statistic(doc)
+    assert values == {
+        "ALL": {"len": 4, "mean": 52, "std": 0.0, "min": 52.0, "max": 52.0},
+        "relation_label_1": {"len": 2, "mean": 52.0, "std": 0.0, "min": 52.0, "max": 52.0},
+        "relation_label_2": {"len": 2, "mean": 52.0, "std": 0.0, "min": 52.0, "max": 52.0},
+    }
+
+
+def test_relation_argument_distance_collector_with_tokenize():
+    doc = TestDocument(
+        text="This is the first entity. This is the second entity. " "This is the third entity."
+    )
+
+    doc.entities.append(LabeledSpan(start=0, end=25, label="entity"))
+    doc.entities.append(LabeledSpan(start=26, end=52, label="entity"))
+    doc.entities.append(LabeledSpan(start=53, end=78, label="entity"))
+    doc.relations.append(
+        BinaryRelation(head=doc.entities[0], tail=doc.entities[1], label="relation_label_1")
+    )
+    doc.relations.append(
+        BinaryRelation(head=doc.entities[1], tail=doc.entities[2], label="relation_label_2")
+    )
+
+    @dataclasses.dataclass
+    class TokenizedTestDocument(TokenBasedDocument):
+        entities: AnnotationList[LabeledSpan] = annotation_field(target="tokens")
+        relations: AnnotationList[BinaryRelation] = annotation_field(target="entities")
+
+    statistic = RelationArgumentDistanceCollector(
+        layer="relations",
+        tokenize=True,
+        tokenizer="bert-base-uncased",
+        tokenized_document_type=TokenizedTestDocument,
+    )
+    values = statistic(doc)
+    assert values == {
+        "ALL": {"len": 4, "mean": 12.0, "std": 0.0, "min": 12.0, "max": 12.0},
+        "relation_label_1": {"len": 2, "mean": 12.0, "std": 0.0, "min": 12.0, "max": 12.0},
+        "relation_label_2": {"len": 2, "mean": 12.0, "std": 0.0, "min": 12.0, "max": 12.0},
+    }
+
+
+def test_relation_argument_distance_collector_with_tokenize_missing_tokenizer():
+    with pytest.raises(ValueError) as excinfo:
+        RelationArgumentDistanceCollector(
+            layer="relations",
+            tokenize=True,
+            tokenized_document_type=TokenBasedDocument,
+        )
+    assert (
+        str(excinfo.value) == "tokenizer must be provided to calculate distance in means of tokens"
+    )
+
+
+def test_relation_argument_distance_collector_with_tokenize_missing_tokenized_document_type():
+    with pytest.raises(ValueError) as excinfo:
+        RelationArgumentDistanceCollector(
+            layer="relations",
+            tokenize=True,
+            tokenizer="bert-base-uncased",
+        )
+    assert (
+        str(excinfo.value)
+        == "tokenized_document_type must be provided to calculate distance in means of tokens"
+    )
+
+
+def test_relation_argument_distance_collector_with_tokenize_wrong_document_type():
+    @dataclasses.dataclass
+    class TestDocument(Document):
+        data: str
+        entities: AnnotationList[LabeledSpan] = annotation_field(target="data")
+        relations: AnnotationList[BinaryRelation] = annotation_field(target="entities")
+
+    doc = TestDocument(
+        data="This is the first entity. This is the second entity. " "This is the third entity."
+    )
+
+    doc.entities.append(LabeledSpan(start=0, end=25, label="entity"))
+    doc.entities.append(LabeledSpan(start=26, end=52, label="entity"))
+    doc.entities.append(LabeledSpan(start=53, end=78, label="entity"))
+    doc.relations.append(
+        BinaryRelation(head=doc.entities[0], tail=doc.entities[1], label="relation_label_1")
+    )
+    doc.relations.append(
+        BinaryRelation(head=doc.entities[1], tail=doc.entities[2], label="relation_label_2")
+    )
+
+    @dataclasses.dataclass
+    class TokenizedTestDocument(TokenBasedDocument):
+        entities: AnnotationList[LabeledSpan] = annotation_field(target="tokens")
+        relations: AnnotationList[BinaryRelation] = annotation_field(target="entities")
+
+    #
+    statistic = RelationArgumentDistanceCollector(
+        layer="relations",
+        tokenize=True,
+        tokenizer="bert-base-uncased",
+        tokenized_document_type=TokenizedTestDocument,
+    )
+
+    with pytest.raises(ValueError) as excinfo:
+        statistic(doc)
+    assert (
+        str(excinfo.value)
+        == "doc must be a TextBasedDocument to calculate distance in means of tokens"
+    )
+
+
+def test_relation_argument_distance_collector_with_tokenize_wrong_span_annotation_type():
+    @dataclasses.dataclass(eq=True, frozen=True)
+    class UnknownSpan(Annotation):
+        start: int
+        end: int
+
+    @dataclasses.dataclass
+    class TestDocument(TextBasedDocument):
+        labeled_multi_spans: AnnotationList[UnknownSpan] = annotation_field(target="text")
+        binary_relations: AnnotationList[BinaryRelation] = annotation_field(
+            target="labeled_multi_spans"
+        )
+
+    doc = TestDocument(text="First sentence. Entity M works at N. And it founded O.")
+    doc.labeled_multi_spans.append(UnknownSpan(start=0, end=15))
+    doc.labeled_multi_spans.append(UnknownSpan(start=16, end=24))
+    doc.binary_relations.append(
+        BinaryRelation(
+            head=doc.labeled_multi_spans[0],
+            tail=doc.labeled_multi_spans[1],
+            label="relation_label_1",
+        )
+    )
+
+    statistic = RelationArgumentDistanceCollector(layer="binary_relations")
+
+    with pytest.raises(TypeError) as excinfo:
+        statistic(doc)
+    assert (
+        str(excinfo.value)
+        == "argument distance calculation is not yet supported for arguments other than Spans"
+    )
+
+
+def test_relation_argument_distance_collector_with_tokenize_wrong_relation_annotation_type():
+    @dataclasses.dataclass(eq=True, frozen=True)
+    class UnknownRelation(Annotation):
+        head: Annotation
+        tail: Annotation
+
+    @dataclasses.dataclass
+    class TestDocument(TextBasedDocument):
+        labeled_spans: AnnotationList[LabeledSpan] = annotation_field(target="text")
+        not_binary_relations: AnnotationList[UnknownRelation] = annotation_field(
+            target="labeled_spans"
+        )
+
+    doc = TestDocument(text="This is the first entity. This is the second entity.")
+    doc.labeled_spans.append(LabeledSpan(start=0, end=25, label="entity"))
+    doc.labeled_spans.append(LabeledSpan(start=26, end=52, label="entity"))
+    doc.not_binary_relations.append(
+        UnknownRelation(head=doc.labeled_spans[0], tail=doc.labeled_spans[1])
+    )
+
+    statistic = RelationArgumentDistanceCollector(layer="not_binary_relations")
+
+    with pytest.raises(TypeError) as excinfo:
+        statistic(doc)
+    assert (
+        str(excinfo.value)
+        == f"argument distance calculation is not yet supported for {UnknownRelation}"
+    )

--- a/tests/metrics/test_relation_argument_distance_collector.py
+++ b/tests/metrics/test_relation_argument_distance_collector.py
@@ -40,26 +40,28 @@ def test_relation_argument_distance_collector():
 
 def test_relation_argument_distance_collector_with_n_ary_relation():
     doc = TestDocument(
-        text="This is the first entity. This is the second entity. And, this is the third entity."
+        text="This is the first entity, which has details. This is the second entity. And, this is the third entity."
     )
     doc.entities.append(LabeledSpan(start=0, end=25, label="entity"))
-    doc.entities.append(LabeledSpan(start=26, end=52, label="entity"))
-    doc.entities.append(LabeledSpan(start=53, end=83, label="entity"))
+    doc.entities.append(LabeledSpan(start=26, end=44, label="entity"))
+    doc.entities.append(LabeledSpan(start=45, end=71, label="entity"))
+    doc.entities.append(LabeledSpan(start=72, end=102, label="entity"))
     doc.relations.append(
         NaryRelation(
             arguments=[
                 doc.entities[0],
                 doc.entities[1],
+                doc.entities[2],
             ],
-            roles=["head", "tail"],
+            roles=["head", "head", "tail"],
             label="relation_label_1",
         )
     )
     doc.relations.append(
         NaryRelation(
             arguments=[
-                doc.entities[1],
                 doc.entities[2],
+                doc.entities[3],
             ],
             roles=["head", "tail"],
             label="relation_label_2",
@@ -69,9 +71,15 @@ def test_relation_argument_distance_collector_with_n_ary_relation():
     statistic = RelationArgumentDistanceCollector(layer="relations")
     values = statistic(doc)
     assert values == {
-        "ALL": {"len": 4, "mean": 54.5, "std": 2.5, "min": 52.0, "max": 57.0},
-        "relation_label_1": {"len": 2, "mean": 52.0, "std": 0.0, "min": 52.0, "max": 52.0},
-        "relation_label_2": {"len": 2, "mean": 57.0, "std": 0.0, "min": 57.0, "max": 57.0},
+        "ALL": {"len": 8, "max": 71.0, "mean": 54.25, "min": 44.0, "std": 10.940178243520533},
+        "relation_label_1": {
+            "len": 6,
+            "max": 71.0,
+            "mean": 53.333333333333336,
+            "min": 44.0,
+            "std": 12.498888839501783,
+        },
+        "relation_label_2": {"len": 2, "max": 57.0, "mean": 57.0, "min": 57.0, "std": 0.0},
     }
 
 
@@ -160,7 +168,6 @@ def test_relation_argument_distance_collector_with_tokenize_wrong_document_type(
         entities: AnnotationList[LabeledSpan] = annotation_field(target="tokens")
         relations: AnnotationList[BinaryRelation] = annotation_field(target="entities")
 
-    #
     statistic = RelationArgumentDistanceCollector(
         layer="relations",
         tokenize=True,

--- a/tests/metrics/test_relation_argument_distance_collector.py
+++ b/tests/metrics/test_relation_argument_distance_collector.py
@@ -38,7 +38,6 @@ def test_relation_argument_distance_collector():
     }
 
 
-@pytest.mark.slow
 def test_relation_argument_distance_collector_with_n_ary_relation():
     doc = TestDocument(
         text="This is the first entity. This is the second entity. And, this is the third entity."


### PR DESCRIPTION
From the docstring:
```
Collects the distances between the arguments of relation annotations. For n-ary relations,
the distances between all pairs of arguments are collected. The distances can be calculated in
means of characters or tokens.

Args:
    layer: The relation annotation layer of the document to collect the distances from.
    distance_type: The type of distance to calculate. Can be "outer", "inner", or "center".
    tokenize: Whether to tokenize the document before calculating the distance.
    tokenizer: The tokenizer to use for tokenization. If a string is provided, the tokenizer is
        loaded from the Hugging Face model hub. Required if tokenize is True.
    tokenized_document_type: The type of document to return after tokenization. Required if
        tokenize is True.
    key_all: The key to use for the aggregation of all values.
```

This requires #70.