### PR TITLE
adjust `trim_text_spans()` to work with `LabeledMultiSpan`

### DIFF
--- a/src/pie_modules/document/processing/text_span_trimmer.py
+++ b/src/pie_modules/document/processing/text_span_trimmer.py
@@ -18,6 +18,7 @@ def trim_text_spans(
     document: D,
     layer: str,
     skip_empty: bool = True,
+    strict: bool = True,
     verbose: bool = True,
 ) -> D:
     """Remove the whitespace at the beginning and end of span annotations that target a text field.
@@ -26,6 +27,8 @@ def trim_text_spans(
         document: The document to trim its span annotations.
         layer: The name of the span layer to trim.
         skip_empty: If True, empty spans will be skipped. Otherwise, an error will be raised.
+        strict: If True, raise an error if a removed span causes a removal of a relation or
+            other annotation that depends on it.
         verbose: If True, log warnings for trimmed spans.
 
     Returns:
@@ -124,7 +127,7 @@ def trim_text_spans(
         override_annotations={layer: old2new_spans},
         removed_annotations={layer: set(removed_span_ids)},
         verbose=verbose,
-        strict=True,
+        strict=strict,
     )
 
     return result
@@ -136,6 +139,8 @@ class TextSpanTrimmer:
     Args:
         layer: The name of the text span layer to trim.
         skip_empty: If True, empty spans will be skipped. Otherwise, an error will be raised.
+        strict: If True, raise an error if a removed span causes a removal of a relation or other
+            annotation that depends on it.
         verbose: If True, log warnings for trimmed spans.
     """
 
@@ -143,10 +148,12 @@ class TextSpanTrimmer:
         self,
         layer: str,
         skip_empty: bool = True,
+        strict: bool = True,
         verbose: bool = True,
     ):
         self.layer = layer
         self.skip_empty = skip_empty
+        self.strict = strict
         self.verbose = verbose
 
     def __call__(self, document: D) -> D:
@@ -154,5 +161,6 @@ class TextSpanTrimmer:
             document=document,
             layer=self.layer,
             skip_empty=self.skip_empty,
+            strict=self.strict,
             verbose=self.verbose,
         )

--- a/tests/document/processing/test_text_span_trimmer.py
+++ b/tests/document/processing/test_text_span_trimmer.py
@@ -147,3 +147,49 @@ def test_text_span_trimmer_with_multi_spans():
     assert len(processed_document.binary_relations) == 1
     assert str(processed_document.labeled_multi_spans[0]) == "('Jane', 'Doe')"
     assert str(processed_document.labeled_multi_spans[1]) == "('New', 'York')"
+
+
+@pytest.mark.parametrize("skip_empty,strict", [(True, True), (False, False)])
+def test_text_span_trimmer_with_multi_spans_that_is_already_empty(skip_empty, strict):
+    doc = DocumentWithLabeledMultiSpansAndBinaryRelations(
+        text="Jane Doe lives in New The Big York."
+    )
+    empty = LabeledMultiSpan(slices=(), label="person")
+    doc.labeled_multi_spans.append(empty)
+    assert str(empty) == "()"
+    new_york = LabeledMultiSpan(slices=((17, 21), (30, 34)), label="city", score=0.9)  # New York
+    doc.labeled_multi_spans.append(new_york)
+    assert str(new_york) == "(' New', 'York')"
+    lives_in = BinaryRelation(head=empty, tail=new_york, label="lives_in", score=0.8)
+    doc.binary_relations.append(lives_in)
+
+    trimmer = TextSpanTrimmer(layer="labeled_multi_spans", skip_empty=skip_empty, strict=strict)
+    if skip_empty and strict:
+        with pytest.raises(ValueError) as excinfo:
+            processed_document = trimmer(doc)
+        assert (
+            str(excinfo.value)
+            == "Could not add annotation BinaryRelation(head=LabeledMultiSpan(slices=(), label='person', score=1.0), "
+            "tail=LabeledMultiSpan(slices=((17, 21), (30, 34)), label='city', score=0.9), label='lives_in', score=0.8) "
+            "to DocumentWithLabeledMultiSpansAndBinaryRelations because it depends on annotations that are not present "
+            "in the document."
+        )
+    else:
+        processed_document = trimmer(doc)
+        if skip_empty:
+            assert len(processed_document.labeled_multi_spans) == 1
+            assert str(processed_document.labeled_multi_spans[0]) == "('New', 'York')"
+            assert len(processed_document.binary_relations) == 0
+        else:
+            assert len(processed_document.labeled_multi_spans) == 2
+            assert str(processed_document.labeled_multi_spans[0]) == "()"
+            assert str(processed_document.labeled_multi_spans[1]) == "('New', 'York')"
+            assert len(processed_document.binary_relations) == 1
+            assert (
+                processed_document.binary_relations[0].head
+                == processed_document.labeled_multi_spans[0]
+            )
+            assert (
+                processed_document.binary_relations[0].tail
+                == processed_document.labeled_multi_spans[1]
+            )


### PR DESCRIPTION
Note that if `skip_empty=True` and `LabeledMultiSpan` did not have any slices in the beginning, it also gets removed. So it is ensured that after applying the trimmer, no empty multi spans are in the data at all what is usually wanted. 

This also adds the parameter `strict` (default: `True`) to disable strict behavior, i.e. allow that dependent annotations such as relations get removed without raising an error when an argument gets removed (because it is empty after trimming).