### PR TITLE
improve `RelationArgumentSorter`

### DIFF
--- a/src/pie_modules/document/processing/relation_argument_sorter.py
+++ b/src/pie_modules/document/processing/relation_argument_sorter.py
@@ -83,22 +83,28 @@ class RelationArgumentSorter:
         #    )
 
         # rel_layer.clear()
+        new_annotations = []
         for args, rel in args2relations.items():
             if self.label_whitelist is not None and rel.label not in self.label_whitelist:
                 # just add the relations whose label is not in the label whitelist (if a whitelist is present)
                 # rel_layer.append(rel)
-                old2new_annotations[rel._id] = rel.copy()
+                new_annotation = rel.copy()
+                old2new_annotations[rel._id] = new_annotation
+                new_annotations.append(new_annotation)
             else:
                 args_sorted = tuple(sorted(args, key=lambda arg: (arg.start, arg.end)))
                 if args == args_sorted:
                     # if the relation args are already sorted, just add the relation
                     # rel_layer.append(rel)
-                    old2new_annotations[rel._id] = rel.copy()
+                    new_annotation = rel.copy()
+                    old2new_annotations[rel._id] = new_annotation
+                    new_annotations.append(new_annotation)
                 else:
                     if args_sorted not in args2relations:
-                        new_rel = construct_relation_with_new_args(rel, args_sorted)
-                        # rel_layer.append(new_rel)
-                        old2new_annotations[rel._id] = new_rel
+                        new_annotation = construct_relation_with_new_args(rel, args_sorted)
+                        # rel_layer.append(new_annotation)
+                        old2new_annotations[rel._id] = new_annotation
+                        new_annotations.append(new_annotation)
                     else:
                         prev_rel = args2relations[args_sorted]
                         if prev_rel.label != rel.label:
@@ -115,11 +121,7 @@ class RelationArgumentSorter:
                             old2new_annotations[rel._id] = prev_rel.copy()
 
         result = doc.copy(with_annotations=False)
-        annotations_deduplicated = []
-        for annotation in old2new_annotations.values():
-            if annotation not in annotations_deduplicated:
-                annotations_deduplicated.append(annotation)
-        result[self.relation_layer].extend(annotations_deduplicated)
+        result[self.relation_layer].extend(new_annotations)
         result.add_all_annotations_from_other(
             doc,
             override_annotations={self.relation_layer: old2new_annotations},

--- a/src/pie_modules/document/processing/relation_argument_sorter.py
+++ b/src/pie_modules/document/processing/relation_argument_sorter.py
@@ -87,13 +87,13 @@ class RelationArgumentSorter:
             if self.label_whitelist is not None and rel.label not in self.label_whitelist:
                 # just add the relations whose label is not in the label whitelist (if a whitelist is present)
                 # rel_layer.append(rel)
-                old2new_annotations[rel._id] = rel
+                old2new_annotations[rel._id] = rel.copy()
             else:
                 args_sorted = tuple(sorted(args, key=lambda arg: (arg.start, arg.end)))
                 if args == args_sorted:
                     # if the relation args are already sorted, just add the relation
                     # rel_layer.append(rel)
-                    old2new_annotations[rel._id] = rel
+                    old2new_annotations[rel._id] = rel.copy()
                 else:
                     if args_sorted not in args2relations:
                         new_rel = construct_relation_with_new_args(rel, args_sorted)
@@ -112,7 +112,7 @@ class RelationArgumentSorter:
                                 f"{prev_rel}"
                             )
                             # removed_annotation_ids.append(rel._id)
-                            old2new_annotations[rel._id] = prev_rel
+                            old2new_annotations[rel._id] = prev_rel.copy()
 
         result = doc.copy(with_annotations=False)
         result[self.relation_layer].extend(old2new_annotations.values())

--- a/src/pie_modules/document/processing/relation_argument_sorter.py
+++ b/src/pie_modules/document/processing/relation_argument_sorter.py
@@ -115,7 +115,11 @@ class RelationArgumentSorter:
                             old2new_annotations[rel._id] = prev_rel.copy()
 
         result = doc.copy(with_annotations=False)
-        result[self.relation_layer].extend(old2new_annotations.values())
+        annotations_deduplicated = []
+        for annotation in old2new_annotations.values():
+            if annotation not in annotations_deduplicated:
+                annotations_deduplicated.append(annotation)
+        result[self.relation_layer].extend(annotations_deduplicated)
         result.add_all_annotations_from_other(
             doc,
             override_annotations={self.relation_layer: old2new_annotations},

--- a/tests/document/processing/test_relation_argument_sorter.py
+++ b/tests/document/processing/test_relation_argument_sorter.py
@@ -32,8 +32,7 @@ def document():
     return doc
 
 
-@pytest.mark.parametrize("inplace", [True, False])
-def test_relation_argument_sorter(document, inplace):
+def test_relation_argument_sorter(document):
     # these arguments are not sorted
     document.binary_relations.append(
         BinaryRelation(
@@ -47,7 +46,7 @@ def test_relation_argument_sorter(document, inplace):
         )
     )
 
-    arg_sorter = RelationArgumentSorter(relation_layer="binary_relations", inplace=inplace)
+    arg_sorter = RelationArgumentSorter(relation_layer="binary_relations")
     doc_sorted_args = arg_sorter(document)
 
     assert document.text == doc_sorted_args.text
@@ -64,10 +63,7 @@ def test_relation_argument_sorter(document, inplace):
     assert str(doc_sorted_args.binary_relations[1].tail) == "I"
     assert doc_sorted_args.binary_relations[1].label == "founded"
 
-    if inplace:
-        assert document == doc_sorted_args
-    else:
-        assert document != doc_sorted_args
+    assert document != doc_sorted_args
 
 
 @pytest.fixture
@@ -140,7 +136,8 @@ def test_relation_argument_sorter_with_label_whitelist(document):
 
     # we only want to sort the relations with the label "founded"
     arg_sorter = RelationArgumentSorter(
-        relation_layer="binary_relations", label_whitelist=["founded"], inplace=False
+        relation_layer="binary_relations",
+        label_whitelist=["founded"],
     )
     doc_sorted_args = arg_sorter(document)
 
@@ -169,7 +166,7 @@ def test_relation_argument_sorter_sorted_rel_already_exists_with_same_label(docu
         )
     )
 
-    arg_sorter = RelationArgumentSorter(relation_layer="binary_relations", inplace=False)
+    arg_sorter = RelationArgumentSorter(relation_layer="binary_relations")
 
     caplog.clear()
     with caplog.at_level(logging.WARNING):
@@ -206,7 +203,7 @@ def test_relation_argument_sorter_sorted_rel_already_exists_with_different_label
         )
     )
 
-    arg_sorter = RelationArgumentSorter(relation_layer="binary_relations", inplace=False)
+    arg_sorter = RelationArgumentSorter(relation_layer="binary_relations")
 
     with pytest.raises(ValueError) as excinfo:
         arg_sorter(document)
@@ -245,7 +242,7 @@ def test_relation_argument_sorter_with_dependent_layers():
         Attribute(annotation=doc.binary_relations[0], label="some_attribute")
     )
 
-    arg_sorter = RelationArgumentSorter(relation_layer="binary_relations", inplace=False)
+    arg_sorter = RelationArgumentSorter(relation_layer="binary_relations")
 
     with pytest.raises(ValueError) as excinfo:
         arg_sorter(doc)

--- a/tests/document/processing/test_relation_argument_sorter.py
+++ b/tests/document/processing/test_relation_argument_sorter.py
@@ -238,16 +238,22 @@ def test_relation_argument_sorter_with_dependent_layers():
     doc.binary_relations.append(
         BinaryRelation(head=doc.labeled_spans[1], tail=doc.labeled_spans[0], label="worksAt")
     )
+    assert str(doc.binary_relations[0].head) == "H"
+    assert str(doc.binary_relations[0].tail) == "Entity G"
     doc.relation_attributes.append(
         Attribute(annotation=doc.binary_relations[0], label="some_attribute")
     )
 
     arg_sorter = RelationArgumentSorter(relation_layer="binary_relations")
 
-    with pytest.raises(ValueError) as excinfo:
-        arg_sorter(doc)
+    doc_sorted_args = arg_sorter(doc)
 
-    assert (
-        str(excinfo.value)
-        == "the relation layer binary_relations has dependent layers, cannot sort the arguments of the relations"
-    )
+    assert doc.text == doc_sorted_args.text
+    assert doc.labeled_spans == doc_sorted_args.labeled_spans
+    assert len(doc_sorted_args.relation_attributes) == len(doc.relation_attributes) == 1
+    new_rel = doc_sorted_args.binary_relations[0]
+    assert str(new_rel.head) == "Entity G"
+    assert str(new_rel.tail) == "H"
+    assert len(doc_sorted_args.relation_attributes) == len(doc.relation_attributes) == 1
+    assert doc_sorted_args.relation_attributes[0].annotation == new_rel
+    assert doc_sorted_args.relation_attributes[0].label == "some_attribute"


### PR DESCRIPTION
This PR improves the `RelationArgumentSorter` in the following ways:
- handle annotations that depend on the relations instead of raising an error, and
- allow `LabeledMultiSpan`s as relation arguments.

Note: this removes the `inplace` parameter to simplify the code. It works now **not inplace**.