### PR TITLE
implement `MultiSpanMerger`

### DIFF
--- a/src/pie_modules/document/processing/__init__.py
+++ b/src/pie_modules/document/processing/__init__.py
@@ -1,3 +1,4 @@
+from .merge_multi_spans import MultiSpanMerger
 from .merge_spans_via_relation import SpansViaRelationMerger
 from .regex_partitioner import RegexPartitioner
 from .relation_argument_sorter import RelationArgumentSorter

--- a/src/pie_modules/document/processing/merge_multi_spans.py
+++ b/src/pie_modules/document/processing/merge_multi_spans.py
@@ -10,6 +10,9 @@ D = TypeVar("D", bound=Document)
 
 
 def multi_span_to_span(multi_span: MultiSpan) -> Span:
+    """Convert a MultiSpan to a Span by taking the start and end of the first and last slice, i.e.
+    create a span that covers all slices of the MultiSpan."""
+
     if len(multi_span.slices) == 0:
         raise ValueError("Cannot convert an empty MultiSpan to a Span.")
     slices_sorted = sorted(multi_span.slices)
@@ -27,6 +30,18 @@ def multi_span_to_span(multi_span: MultiSpan) -> Span:
 
 
 class MultiSpanMerger(Generic[D]):
+    """Merges MultiSpans in the given layer of the input document into Spans in the result
+    document.
+
+    Args:
+        layer: The name of the annotation layer that contains the MultiSpans to merge.
+        result_document_type: The type of the result document.
+        result_field_mapping: A dictionary that maps the layer name of the input document to the
+            layer name of the result document. If None, the layer name of the input document is used
+            as the layer name of the result document. Required if the layer name of the result
+            document is different from the layer name of the input document.
+    """
+
     def __init__(
         self,
         layer: str,

--- a/src/pie_modules/document/processing/merge_multi_spans.py
+++ b/src/pie_modules/document/processing/merge_multi_spans.py
@@ -1,12 +1,22 @@
 from __future__ import annotations
 
-from typing import Generic, TypeVar
+from typing import Generic, TypeVar, overload
 
 from pytorch_ie import Document
 
 from pie_modules.annotations import LabeledMultiSpan, LabeledSpan, MultiSpan, Span
 
 D = TypeVar("D", bound=Document)
+
+
+@overload
+def multi_span_to_span(multi_span: LabeledMultiSpan) -> LabeledSpan:
+    ...
+
+
+@overload
+def multi_span_to_span(multi_span: MultiSpan) -> Span:
+    ...
 
 
 def multi_span_to_span(multi_span: MultiSpan) -> Span:

--- a/src/pie_modules/document/processing/merge_multi_spans.py
+++ b/src/pie_modules/document/processing/merge_multi_spans.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from typing import Generic, TypeVar
+
+from pytorch_ie import Document
+
+from pie_modules.annotations import LabeledMultiSpan, LabeledSpan, MultiSpan, Span
+
+D = TypeVar("D", bound=Document)
+
+
+def multi_span_to_span(multi_span: MultiSpan) -> Span:
+    if len(multi_span.slices) == 0:
+        raise ValueError("Cannot convert an empty MultiSpan to a Span.")
+    slices_sorted = sorted(multi_span.slices)
+    span_dict = multi_span.asdict()
+    span_dict.pop("slices")
+    span_dict.pop("_id")
+    span_dict["start"] = slices_sorted[0][0]
+    span_dict["end"] = slices_sorted[-1][1]
+    if isinstance(multi_span, LabeledMultiSpan):
+        return LabeledSpan(**span_dict)
+    elif isinstance(multi_span, MultiSpan):
+        return Span(**span_dict)
+    else:
+        raise ValueError(f"Unknown MultiSpan type: {type(multi_span)}")
+
+
+class MultiSpanMerger(Generic[D]):
+    def __init__(
+        self,
+        layer: str,
+        result_document_type: type[D],
+        result_field_mapping: dict[str, str] | None = None,
+    ):
+        self.layer = layer
+        self.result_document_type = result_document_type
+        self.result_field_mapping = result_field_mapping or {}
+
+    def __call__(self, document: Document) -> D:
+        result: D = document.copy(with_annotations=False).as_type(
+            new_type=self.result_document_type, field_mapping=self.result_field_mapping
+        )
+        target_layer_name = self.result_field_mapping.get(self.layer, self.layer)
+        source_layer = document[self.layer]
+        target_layer = result[target_layer_name]
+        span_mapping: dict[int, Span] = {}
+        # process gold annotations
+        for multi_span in source_layer:
+            new_span = multi_span_to_span(multi_span)
+            span_mapping[multi_span._id] = new_span
+            target_layer.append(new_span)
+        # process predicted annotations
+        for multi_span in source_layer.predictions:
+            new_span = multi_span_to_span(multi_span)
+            span_mapping[multi_span._id] = new_span
+            target_layer.predictions.append(new_span)
+
+        result.add_all_annotations_from_other(
+            document, override_annotations={target_layer_name: span_mapping}
+        )
+        return result

--- a/tests/document/processing/test_merge_multi_spans.py
+++ b/tests/document/processing/test_merge_multi_spans.py
@@ -1,9 +1,47 @@
-from pie_modules.annotations import BinaryRelation, LabeledMultiSpan, LabeledSpan
+import pytest
+from pytorch_ie.annotations import Span
+
+from pie_modules.annotations import (
+    BinaryRelation,
+    LabeledMultiSpan,
+    LabeledSpan,
+    MultiSpan,
+)
 from pie_modules.document.processing import MultiSpanMerger
+from pie_modules.document.processing.merge_multi_spans import multi_span_to_span
 from pie_modules.documents import (
     TextDocumentWithLabeledMultiSpansBinaryRelationsAndLabeledPartitions,
     TextDocumentWithLabeledSpansBinaryRelationsAndLabeledPartitions,
 )
+
+
+@pytest.mark.parametrize("not_sorted", [False, True])
+def test_multi_span_to_span(not_sorted):
+    if not_sorted:
+        multi_span = MultiSpan(slices=((4, 6), (0, 2)))
+    else:
+        multi_span = MultiSpan(slices=((0, 2), (4, 6)))
+    span = multi_span_to_span(multi_span)
+    assert isinstance(span, Span)
+    assert span.start == 0
+    assert span.end == 6
+
+
+def test_multi_span_to_span_empty():
+    multi_span = MultiSpan(slices=())
+    with pytest.raises(ValueError) as excinfo:
+        multi_span_to_span(multi_span)
+    assert str(excinfo.value) == "Cannot convert an empty MultiSpan to a Span."
+
+
+def test_labeled_multi_span_to_span():
+    multi_span = LabeledMultiSpan(slices=((0, 2), (4, 6)), label="label_a", score=0.5)
+    span = multi_span_to_span(multi_span)
+    assert isinstance(span, LabeledSpan)
+    assert span.start == 0
+    assert span.end == 6
+    assert span.label == "label_a"
+    assert span.score == 0.5
 
 
 def test_multi_span_merger():

--- a/tests/document/processing/test_merge_multi_spans.py
+++ b/tests/document/processing/test_merge_multi_spans.py
@@ -1,0 +1,51 @@
+from pie_modules.annotations import BinaryRelation, LabeledMultiSpan, LabeledSpan
+from pie_modules.document.processing import MultiSpanMerger
+from pie_modules.documents import (
+    TextDocumentWithLabeledMultiSpansBinaryRelationsAndLabeledPartitions,
+    TextDocumentWithLabeledSpansBinaryRelationsAndLabeledPartitions,
+)
+
+
+def test_multi_span_merger():
+    doc = TextDocumentWithLabeledMultiSpansBinaryRelationsAndLabeledPartitions(
+        text='He lives in New "Never Sleeping" York.'
+    )
+    he = LabeledMultiSpan(slices=((0, 2),), label="PER")
+    doc.labeled_multi_spans.append(he)
+    assert str(he) == "('He',)"
+    new_york = LabeledMultiSpan(slices=((12, 15), (33, 37)), label="LOC")
+    doc.labeled_multi_spans.append(new_york)
+    assert str(new_york) == "('New', 'York')"
+    # same as new_york but with a different end
+    new_york_prediction = LabeledMultiSpan(slices=((12, 15), (33, 38)), label="LOC")
+    doc.labeled_multi_spans.predictions.append(new_york_prediction)
+    assert str(new_york_prediction) == "('New', 'York.')"
+    lives_in = BinaryRelation(head=he, tail=new_york, label="lives_in")
+    doc.binary_relations.append(lives_in)
+    sentence = LabeledSpan(start=0, end=len(doc.text), label="SENTENCE")
+    doc.labeled_partitions.append(sentence)
+    assert str(sentence) == 'He lives in New "Never Sleeping" York.'
+
+    multi_span_merger = MultiSpanMerger(
+        result_document_type=TextDocumentWithLabeledSpansBinaryRelationsAndLabeledPartitions,
+        layer="labeled_multi_spans",
+        result_field_mapping={
+            "labeled_multi_spans": "labeled_spans",
+        },
+    )
+    result = multi_span_merger(doc)
+    assert len(result.labeled_spans) == 2
+    assert str(result.labeled_spans[0]) == "He"
+    assert result.labeled_spans[0].label == he.label == "PER"
+    assert str(result.labeled_spans[1]) == 'New "Never Sleeping" York'
+    assert result.labeled_spans[1].label == new_york.label == "LOC"
+    assert len(result.labeled_spans.predictions) == 1
+    assert str(result.labeled_spans.predictions[0]) == 'New "Never Sleeping" York.'
+    assert result.labeled_spans.predictions[0].label == new_york_prediction.label == "LOC"
+    assert len(result.binary_relations) == 1
+    assert result.binary_relations[0].head == result.labeled_spans[0]
+    assert result.binary_relations[0].tail == result.labeled_spans[1]
+    assert result.binary_relations[0].label == lives_in.label == "lives_in"
+    assert len(result.labeled_partitions) == 1
+    assert str(result.labeled_partitions[0]) == 'He lives in New "Never Sleeping" York.'
+    assert result.labeled_partitions[0].label == sentence.label == "SENTENCE"

--- a/tests/document/processing/test_merge_multi_spans.py
+++ b/tests/document/processing/test_merge_multi_spans.py
@@ -67,9 +67,7 @@ def test_multi_span_merger():
     multi_span_merger = MultiSpanMerger(
         result_document_type=TextDocumentWithLabeledSpansBinaryRelationsAndLabeledPartitions,
         layer="labeled_multi_spans",
-        result_field_mapping={
-            "labeled_multi_spans": "labeled_spans",
-        },
+        target_layer="labeled_spans",
     )
     result = multi_span_merger(doc)
     assert len(result.labeled_spans) == 2

--- a/tests/document/processing/test_merge_multi_spans.py
+++ b/tests/document/processing/test_merge_multi_spans.py
@@ -1,4 +1,7 @@
+import dataclasses
+
 import pytest
+from pytorch_ie import Annotation
 
 from pie_modules.annotations import (
     BinaryRelation,
@@ -21,7 +24,7 @@ def test_multi_span_to_span(not_sorted):
         multi_span = MultiSpan(slices=((4, 6), (0, 2)))
     else:
         multi_span = MultiSpan(slices=((0, 2), (4, 6)))
-    span = multi_span_to_span(multi_span)
+    span = multi_span_to_span(multi_span, result_type=Span)
     assert isinstance(span, Span)
     assert span.start == 0
     assert span.end == 6
@@ -30,13 +33,13 @@ def test_multi_span_to_span(not_sorted):
 def test_multi_span_to_span_empty():
     multi_span = MultiSpan(slices=())
     with pytest.raises(ValueError) as excinfo:
-        multi_span_to_span(multi_span)
+        multi_span_to_span(multi_span, result_type=Span)
     assert str(excinfo.value) == "Cannot convert an empty MultiSpan to a Span."
 
 
 def test_labeled_multi_span_to_span():
     multi_span = LabeledMultiSpan(slices=((0, 2), (4, 6)), label="label_a", score=0.5)
-    span = multi_span_to_span(multi_span)
+    span = multi_span_to_span(multi_span, result_type=LabeledSpan)
     assert isinstance(span, LabeledSpan)
     assert span.start == 0
     assert span.end == 6

--- a/tests/document/processing/test_merge_multi_spans.py
+++ b/tests/document/processing/test_merge_multi_spans.py
@@ -1,7 +1,4 @@
-import dataclasses
-
 import pytest
-from pytorch_ie import Annotation
 
 from pie_modules.annotations import (
     BinaryRelation,

--- a/tests/document/processing/test_merge_multi_spans.py
+++ b/tests/document/processing/test_merge_multi_spans.py
@@ -1,11 +1,11 @@
 import pytest
-from pytorch_ie.annotations import Span
 
 from pie_modules.annotations import (
     BinaryRelation,
     LabeledMultiSpan,
     LabeledSpan,
     MultiSpan,
+    Span,
 )
 from pie_modules.document.processing import MultiSpanMerger
 from pie_modules.document.processing.merge_multi_spans import multi_span_to_span


### PR DESCRIPTION
This PR adds the `MultiSpanMerger` document processor. From the dosctring:
``` 
Merges MultiSpans in the given layer of the input document into Spans in the result
document.

Args:
    layer: The name of the annotation layer that contains the MultiSpans to merge.
    result_document_type: The type of the result document.
    target_layer: The name of the annotation layer in the result document where the merged
        Spans should be added. If not provided, the same name as the input layer will be used.
```