### PR TITLE
remove parameter `span_layer_name` from `PointerNetworkTaskModuleForEnd2EndRE`

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1110,20 +1110,24 @@ name = "pytorch-ie"
 version = "0.30.0"
 description = "State-of-the-art Information Extraction in PyTorch"
 optional = false
-python-versions = ">=3.9,<4.0"
-files = [
-    {file = "pytorch_ie-0.30.0-py3-none-any.whl", hash = "sha256:519d9f30f08bee4ce50cacd01c8a96ffd9f8ac80f5ad031bc71760204f0dda8c"},
-    {file = "pytorch_ie-0.30.0.tar.gz", hash = "sha256:82d9526164d0cabf5d4e629167ee8e0f36bed63f8c71e6d76edbe1eec8bf5449"},
-]
+python-versions = "^3.9"
+files = []
+develop = false
 
 [package.dependencies]
-absl-py = ">=1.0.0,<2.0.0"
+absl-py = "^1.0.0"
 fsspec = "<2023.9.0"
-pandas = ">=2.0.0,<3.0.0"
-pytorch-lightning = ">=2,<3"
+pandas = "^2.0.0"
+pytorch-lightning = "^2"
 torch = ">=1.10"
-torchmetrics = ">=1,<2"
-transformers = ">=4.18,<5.0"
+torchmetrics = "^1"
+transformers = "^4.18"
+
+[package.source]
+type = "git"
+url = "https://github.com/arnebinder/pytorch-ie"
+reference = "document_target_names"
+resolved_reference = "ddb50ee5fe6695c5beb8d965ce8ccaccbd828e82"
 
 [[package]]
 name = "pytorch-lightning"
@@ -1944,4 +1948,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "cb5b3ad5422c31ab6ce27a1f34a7ea982aba476d9c53e9a97018ddb3d2ffcb00"
+content-hash = "bd76b3b2c71dd6d233a5946e9dca699e95905ca30f871e3146d39444e730d2f0"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1107,27 +1107,23 @@ files = [
 
 [[package]]
 name = "pytorch-ie"
-version = "0.30.0"
+version = "0.30.1"
 description = "State-of-the-art Information Extraction in PyTorch"
 optional = false
-python-versions = "^3.9"
-files = []
-develop = false
+python-versions = "<4.0,>=3.9"
+files = [
+    {file = "pytorch_ie-0.30.1-py3-none-any.whl", hash = "sha256:f50e9864dbc1d07ae8be0ab003b40af517f923888c7200fcb08e97c479e26bb7"},
+    {file = "pytorch_ie-0.30.1.tar.gz", hash = "sha256:4c64a70111928f6b4a03fbe0b992c3ba4b248f614026f0a319733fdb1a66aaf5"},
+]
 
 [package.dependencies]
-absl-py = "^1.0.0"
+absl-py = ">=1.0.0,<2.0.0"
 fsspec = "<2023.9.0"
-pandas = "^2.0.0"
-pytorch-lightning = "^2"
+pandas = ">=2.0.0,<3.0.0"
+pytorch-lightning = ">=2,<3"
 torch = ">=1.10"
-torchmetrics = "^1"
-transformers = "^4.18"
-
-[package.source]
-type = "git"
-url = "https://github.com/arnebinder/pytorch-ie"
-reference = "document_target_names"
-resolved_reference = "ddb50ee5fe6695c5beb8d965ce8ccaccbd828e82"
+torchmetrics = ">=1,<2"
+transformers = ">=4.18,<5.0"
 
 [[package]]
 name = "pytorch-lightning"
@@ -1948,4 +1944,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "bd76b3b2c71dd6d233a5946e9dca699e95905ca30f871e3146d39444e730d2f0"
+content-hash = "d7d961e5baaa93a638549e16ed444a7e01092ad2d17ace33d5f958bd3b9d5ec0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,9 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.9"
-pytorch-ie = ">=0.29.8,<0.31.0"
+#pytorch-ie = ">=0.30.1,<0.31.0"
+# install from branch document_target_names
+pytorch-ie = { git = "https://github.com/arnebinder/pytorch-ie", branch = "document_target_names" }
 pytorch-lightning = "^2.1.0"
 torchmetrics = "^1"
 pytorch-crf = ">=0.7.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,9 +24,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.9"
-#pytorch-ie = ">=0.30.1,<0.31.0"
-# install from branch document_target_names
-pytorch-ie = { git = "https://github.com/arnebinder/pytorch-ie", branch = "document_target_names" }
+pytorch-ie = ">=0.30.1,<0.31.0"
 pytorch-lightning = "^2.1.0"
 torchmetrics = "^1"
 pytorch-crf = ">=0.7.2"

--- a/src/pie_modules/taskmodules/pointer_network_for_end2end_re.py
+++ b/src/pie_modules/taskmodules/pointer_network_for_end2end_re.py
@@ -152,7 +152,10 @@ class PointerNetworkTaskModuleForEnd2EndRE(
         self.annotation_field_mapping = annotation_field_mapping or dict()
         annotation_field_mapping_inv = {v: k for k, v in self.annotation_field_mapping.items()}
         if len(self.annotation_field_mapping) != len(annotation_field_mapping_inv):
-            raise Exception("annotation_field_mapping is not bijective")
+            raise Exception(
+                f"inverted annotation_field_mapping is not unique. annotation_field_mapping: "
+                f"{self.annotation_field_mapping}"
+            )
         self.partition_layer_name = partition_layer_name
 
         # for this specific use case: end-to-end relation extraction

--- a/src/pie_modules/taskmodules/pointer_network_for_end2end_re.py
+++ b/src/pie_modules/taskmodules/pointer_network_for_end2end_re.py
@@ -113,7 +113,6 @@ class PointerNetworkTaskModuleForEnd2EndRE(
         # specific for this use case
         document_type: str = "pytorch_ie.documents.TextDocumentWithLabeledSpansBinaryRelationsAndLabeledPartitions",
         tokenized_document_type: str = "pie_modules.documents.TokenDocumentWithLabeledSpansBinaryRelationsAndLabeledPartitions",
-        span_layer_name: str = "labeled_spans",
         relation_layer_name: str = "binary_relations",
         none_label: str = "none",
         loop_dummy_relation_name: str = "loop",
@@ -151,11 +150,20 @@ class PointerNetworkTaskModuleForEnd2EndRE(
             **(tokenizer_init_kwargs or {}),
         )
         self.annotation_field_mapping = annotation_field_mapping or dict()
+        annotation_field_mapping_inv = {v: k for k, v in self.annotation_field_mapping.items()}
+        if len(self.annotation_field_mapping) != len(annotation_field_mapping_inv):
+            raise Exception("annotation_field_mapping is not bijective")
         self.partition_layer_name = partition_layer_name
 
         # for this specific use case: end-to-end relation extraction
-        self.span_layer_name = span_layer_name
         self.relation_layer_name = relation_layer_name
+        relation_layer_mapped = self.annotation_field_mapping.get(
+            relation_layer_name, relation_layer_name
+        )
+        relation_layer_target = self.document_type.target_name(relation_layer_mapped)
+        self.span_layer_name = annotation_field_mapping_inv.get(
+            relation_layer_target, relation_layer_target
+        )
         self.none_label = none_label
         self.loop_dummy_relation_name = loop_dummy_relation_name
         self.constrained_generation = constrained_generation

--- a/src/pie_modules/taskmodules/pointer_network_for_end2end_re.py
+++ b/src/pie_modules/taskmodules/pointer_network_for_end2end_re.py
@@ -152,7 +152,7 @@ class PointerNetworkTaskModuleForEnd2EndRE(
         self.annotation_field_mapping = annotation_field_mapping or dict()
         annotation_field_mapping_inv = {v: k for k, v in self.annotation_field_mapping.items()}
         if len(self.annotation_field_mapping) != len(annotation_field_mapping_inv):
-            raise Exception(
+            raise ValueError(
                 f"inverted annotation_field_mapping is not unique. annotation_field_mapping: "
                 f"{self.annotation_field_mapping}"
             )

--- a/tests/taskmodules/test_pointer_network_for_end2end_re.py
+++ b/tests/taskmodules/test_pointer_network_for_end2end_re.py
@@ -106,7 +106,6 @@ def test_document(document):
 def taskmodule(document, config):
     taskmodule = PointerNetworkTaskModuleForEnd2EndRE(
         tokenizer_name_or_path="facebook/bart-base",
-        span_layer_name="entities",
         relation_layer_name="relations",
         exclude_labels_per_layer={"relations": ["no_relation"]},
         annotation_field_mapping={
@@ -177,7 +176,6 @@ def test_prepared_config(taskmodule, config):
     if config == {}:
         assert taskmodule._config() == {
             "taskmodule_type": "PointerNetworkTaskModuleForEnd2EndRE",
-            "span_layer_name": "entities",
             "relation_layer_name": "relations",
             "none_label": "none",
             "loop_dummy_relation_name": "loop",
@@ -205,7 +203,6 @@ def test_prepared_config(taskmodule, config):
     elif config == {"partition_layer_name": "sentences"}:
         assert taskmodule._config() == {
             "taskmodule_type": "PointerNetworkTaskModuleForEnd2EndRE",
-            "span_layer_name": "entities",
             "relation_layer_name": "relations",
             "none_label": "none",
             "loop_dummy_relation_name": "loop",

--- a/tests/taskmodules/test_pointer_network_for_end2end_re.py
+++ b/tests/taskmodules/test_pointer_network_for_end2end_re.py
@@ -172,6 +172,22 @@ def test_taskmodule(taskmodule):
     assert taskmodule.target_token_ids == [0, 2, 50266, 50269, 50268, 50265, 50267]
 
 
+def test_taskmodule_with_wrong_annotation_field_mapping():
+    with pytest.raises(ValueError) as exc_info:
+        PointerNetworkTaskModuleForEnd2EndRE(
+            tokenizer_name_or_path="facebook/bart-base",
+            relation_layer_name="relations",
+            annotation_field_mapping={
+                "entities": "labeled_spans",
+                "sentences": "labeled_spans",
+            },
+        )
+    assert str(exc_info.value) == (
+        "inverted annotation_field_mapping is not unique. annotation_field_mapping: "
+        "{'entities': 'labeled_spans', 'sentences': 'labeled_spans'}"
+    )
+
+
 def test_prepared_config(taskmodule, config):
     if config == {}:
         assert taskmodule._config() == {


### PR DESCRIPTION
This PR removes the parameter `span_layer_name` from the `PointerNetworkTaskModuleForEnd2EndRE` because we can infer this from the target of the relation annotation layer. It is breaking because: 1) the parameter is removed, and 2) we require `pytorch-ie>=0.30.1` because of https://github.com/ArneBinder/pytorch-ie/pull/407.