### PR TITLE
cleanup `PointerHead` logic  regarding `decoder_position_id_mode`

### DIFF
--- a/src/pie_modules/models/base_models/bart_as_pointer_network.py
+++ b/src/pie_modules/models/base_models/bart_as_pointer_network.py
@@ -47,7 +47,6 @@ class BartAsPointerNetworkConfig(BartConfig):
         decoder_position_id_mode: Optional[str] = None,
         decoder_position_id_pattern: Optional[List[int]] = None,
         decoder_position_id_mapping: Optional[Dict[int, int]] = None,
-        increase_position_ids_per_record: bool = False,
         # other parameters
         use_encoder_mlp: bool = True,
         use_constraints_encoder_mlp: bool = False,
@@ -73,7 +72,6 @@ class BartAsPointerNetworkConfig(BartConfig):
         self.decoder_position_id_mode = decoder_position_id_mode
         self.decoder_position_id_pattern = decoder_position_id_pattern
         self.decoder_position_id_mapping = decoder_position_id_mapping
-        self.increase_position_ids_per_record = increase_position_ids_per_record
 
         self.lr = lr
         self.weight_decay = weight_decay
@@ -93,11 +91,7 @@ class BartAsPointerNetwork(BartPreTrainedModel):
 
     def __init__(self, config: BartAsPointerNetworkConfig):
         super().__init__(config)
-        # TODO: remove "or self.config.decoder_position_id_pattern is not None" when backward compatibility is removed
-        if (
-            self.config.decoder_position_id_mode is not None
-            or self.config.decoder_position_id_pattern is not None
-        ):
+        if self.config.decoder_position_id_mode is not None:
             self.model = BartModelWithDecoderPositionIds(config)
         else:
             self.model = BartModel(config)
@@ -118,7 +112,6 @@ class BartAsPointerNetwork(BartPreTrainedModel):
             decoder_position_id_mode=self.model.config.decoder_position_id_mode,
             decoder_position_id_pattern=self.model.config.decoder_position_id_pattern,
             decoder_position_id_mapping=self.model.config.decoder_position_id_mapping,
-            increase_position_ids_per_record=self.model.config.increase_position_ids_per_record,
         )
 
         # Initialize weights and apply final processing


### PR DESCRIPTION
remove parameter increase_position_ids_per_record from BartAsPointerNetworkConfig and from PointerHead; do not automatically select decoder_position_id_mode=pattern if decoder_position_id_pattern is provided