### PR TITLE
use multi span annotations and documents from PyTorch-IE

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1107,13 +1107,13 @@ files = [
 
 [[package]]
 name = "pytorch-ie"
-version = "0.30.1"
+version = "0.30.3"
 description = "State-of-the-art Information Extraction in PyTorch"
 optional = false
 python-versions = "<4.0,>=3.9"
 files = [
-    {file = "pytorch_ie-0.30.1-py3-none-any.whl", hash = "sha256:f50e9864dbc1d07ae8be0ab003b40af517f923888c7200fcb08e97c479e26bb7"},
-    {file = "pytorch_ie-0.30.1.tar.gz", hash = "sha256:4c64a70111928f6b4a03fbe0b992c3ba4b248f614026f0a319733fdb1a66aaf5"},
+    {file = "pytorch_ie-0.30.3-py3-none-any.whl", hash = "sha256:45b0d32817ee5803e785cd75c88eb4fc84cc5764eb05f199a820d22db3f434e3"},
+    {file = "pytorch_ie-0.30.3.tar.gz", hash = "sha256:9743d27e430ba4f21a62362a8873cf9d71549477231b6216a19827ec6f3aa963"},
 ]
 
 [package.dependencies]
@@ -1944,4 +1944,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "d7d961e5baaa93a638549e16ed444a7e01092ad2d17ace33d5f958bd3b9d5ec0"
+content-hash = "29843273b5994c5f962144259577da05e2d9343cabdc1f3f9e215a229e6f30e6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.9"
-pytorch-ie = ">=0.30.1,<0.31.0"
+pytorch-ie = ">=0.30.3,<0.31.0"
 pytorch-lightning = "^2.1.0"
 torchmetrics = "^1"
 pytorch-crf = ">=0.7.2"

--- a/src/pie_modules/annotations.py
+++ b/src/pie_modules/annotations.py
@@ -5,20 +5,17 @@ from typing import Optional, Tuple
 from pytorch_ie.annotations import (
     BinaryRelation,
     Label,
+    LabeledMultiSpan,
     LabeledSpan,
     MultiLabel,
     MultiLabeledBinaryRelation,
     MultiLabeledSpan,
+    MultiSpan,
     NaryRelation,
     Span,
     _post_init_single_label,
 )
 from pytorch_ie.core import Annotation
-
-
-def _post_init_multi_span(self):
-    if isinstance(self.slices, list):
-        object.__setattr__(self, "slices", tuple(tuple(s) for s in self.slices))
 
 
 @dataclasses.dataclass(eq=True, frozen=True)
@@ -66,26 +63,3 @@ class GenerativeAnswer(AnnotationWithText):
 
     score: Optional[float] = dataclasses.field(default=None, compare=False)
     question: Optional[Question] = None
-
-
-@dataclasses.dataclass(eq=True, frozen=True)
-class MultiSpan(Annotation):
-    slices: Tuple[Tuple[int, int], ...]
-
-    def __post_init__(self) -> None:
-        _post_init_multi_span(self)
-
-    def __str__(self) -> str:
-        if not self.is_attached:
-            return super().__str__()
-        return str(tuple(self.target[start:end] for start, end in self.slices))
-
-
-@dataclasses.dataclass(eq=True, frozen=True)
-class LabeledMultiSpan(MultiSpan):
-    label: str
-    score: float = dataclasses.field(default=1.0, compare=False)
-
-    def __post_init__(self) -> None:
-        super().__post_init__()
-        _post_init_single_label(self)

--- a/src/pie_modules/documents.py
+++ b/src/pie_modules/documents.py
@@ -6,6 +6,10 @@ from pytorch_ie.core import AnnotationLayer, AnnotationList, annotation_field
 from pytorch_ie.documents import (
     TextBasedDocument,
     TextDocumentWithLabel,
+    TextDocumentWithLabeledMultiSpans,
+    TextDocumentWithLabeledMultiSpansAndBinaryRelations,
+    TextDocumentWithLabeledMultiSpansAndLabeledPartitions,
+    TextDocumentWithLabeledMultiSpansBinaryRelationsAndLabeledPartitions,
     TextDocumentWithLabeledPartitions,
     TextDocumentWithLabeledSpans,
     TextDocumentWithLabeledSpansAndBinaryRelations,
@@ -120,33 +124,6 @@ class TokenDocumentWithAbstractiveSummary(TokenBasedDocument):
     """A tokenized PIE document with annotations for abstractive summarization."""
 
     abstractive_summary: AnnotationLayer[AbstractiveSummary] = annotation_field()
-
-
-@dataclasses.dataclass
-class TextDocumentWithLabeledMultiSpans(TextBasedDocument):
-    labeled_multi_spans: AnnotationLayer[LabeledMultiSpan] = annotation_field(target="text")
-
-
-@dataclasses.dataclass
-class TextDocumentWithLabeledMultiSpansAndLabeledPartitions(
-    TextDocumentWithLabeledMultiSpans, TextDocumentWithLabeledPartitions
-):
-    pass
-
-
-@dataclasses.dataclass
-class TextDocumentWithLabeledMultiSpansAndBinaryRelations(TextDocumentWithLabeledMultiSpans):
-    binary_relations: AnnotationLayer[BinaryRelation] = annotation_field(
-        target="labeled_multi_spans"
-    )
-
-
-@dataclasses.dataclass
-class TextDocumentWithLabeledMultiSpansBinaryRelationsAndLabeledPartitions(
-    TextDocumentWithLabeledMultiSpansAndLabeledPartitions,
-    TextDocumentWithLabeledMultiSpansAndBinaryRelations,
-):
-    pass
 
 
 @dataclasses.dataclass


### PR DESCRIPTION
This PR removes the annotation types:
- MultiSpan
- LabeledMultiSpan

and the document types:
 - TextDocumentWithLabeledMultiSpans,
 - TextDocumentWithLabeledMultiSpansAndBinaryRelations, 
 - TextDocumentWithLabeledMultiSpansAndLabeledPartitions, and
 - TextDocumentWithLabeledMultiSpansBinaryRelationsAndLabeledPartitions

Theses types are re-exported so that there is no change on the surface.

Note that, in contrast to the previous implementations, the annotation types in PyTorch-IE implement `resolve()`.

This requires [`pytorch-ie>=0.30.3`](https://github.com/ArneBinder/pytorch-ie/releases/tag/v0.30.3).
