### PR TITLE
add `NltkSentenceSplitter`

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1944,4 +1944,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "29843273b5994c5f962144259577da05e2d9343cabdc1f3f9e215a229e6f30e6"
+content-hash = "87a3fcd8d4cb54989c9de510da59885556225b586e5dcc023c8ce6354acf5e39"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,8 @@ pytorch-crf = ">=0.7.2"
 networkx = "^3.0.0"
 # because of BartModelWithDecoderPositionIds
 transformers = "^4.35.0"
+# for NltkSentenceSplitter
+nltk = "^3.8.1"
 
 [tool.poetry.group.dev.dependencies]
 torch = {version = "^2.1.0+cpu", source = "pytorch"}

--- a/src/pie_modules/document/processing/__init__.py
+++ b/src/pie_modules/document/processing/__init__.py
@@ -2,6 +2,7 @@ from .merge_multi_spans import MultiSpanMerger
 from .merge_spans_via_relation import SpansViaRelationMerger
 from .regex_partitioner import RegexPartitioner
 from .relation_argument_sorter import RelationArgumentSorter
+from .sentence_splitter import NltkSentenceSplitter
 from .text_span_trimmer import TextSpanTrimmer
 from .tokenization import (
     text_based_document_to_token_based,

--- a/src/pie_modules/document/processing/sentence_splitter.py
+++ b/src/pie_modules/document/processing/sentence_splitter.py
@@ -14,17 +14,6 @@ logger = logging.getLogger(__name__)
 D = TypeVar("D", bound=TextDocumentWithLabeledPartitions)
 
 
-def get_nltk_resource(resource_name: str, resource_url: str):
-    try:
-        _create_unverified_https_context = ssl._create_unverified_context
-    except AttributeError:
-        pass
-    else:
-        ssl._create_default_https_context = _create_unverified_https_context
-    nltk.download(resource_name)
-    return nltk.data.load(resource_url)
-
-
 class NltkSentenceSplitter:
     """A document processor that adds sentence partitions to a TextDocumentWithLabeledPartitions document.
     It uses the NLTK Punkt tokenizer to split the text of the document into sentences. See
@@ -45,7 +34,9 @@ class NltkSentenceSplitter:
     ):
         self.partition_layer_name = partition_layer_name
         self.text_field_name = text_field_name
-        self.sentencizer = get_nltk_resource(resource_name="punkt", resource_url=sentencizer_url)
+        # download the NLTK Punkt tokenizer model
+        nltk.download("punkt")
+        self.sentencizer = nltk.data.load(sentencizer_url)
 
     def __call__(self, document: D) -> None:
         partition_layer = document[self.partition_layer_name]

--- a/src/pie_modules/document/processing/sentence_splitter.py
+++ b/src/pie_modules/document/processing/sentence_splitter.py
@@ -14,6 +14,16 @@ D = TypeVar("D", bound=TextDocumentWithLabeledPartitions)
 
 
 class NltkSentenceSplitter:
+    """A document processor that splits the text of a document into sentences using the NLTK Punkt
+    tokenizer, see https://www.nltk.org/api/nltk.tokenize.html#nltk.tokenize.punkt.PunktSentenceTokenizer.
+
+    Args:
+        partition_layer_name: The name of the partition layer to add the sentence partitions to. This layer
+            must be an AnnotationLayer of LabeledSpan annotations.
+        text_field_name: The name of the text field in the document to split into sentences.
+        sentencizer_url: The URL to the NLTK Punkt tokenizer model.
+    """
+
     def __init__(
         self,
         partition_layer_name: str = "labeled_partitions",

--- a/src/pie_modules/document/processing/sentence_splitter.py
+++ b/src/pie_modules/document/processing/sentence_splitter.py
@@ -45,7 +45,7 @@ class NltkSentenceSplitter:
     ):
         self.partition_layer_name = partition_layer_name
         self.text_field_name = text_field_name
-        self.sentencizer = get_nltk_resource(resource_name="punbkt", resource_url=sentencizer_url)
+        self.sentencizer = get_nltk_resource(resource_name="punkt", resource_url=sentencizer_url)
 
     def __call__(self, document: D) -> None:
         partition_layer = document[self.partition_layer_name]

--- a/src/pie_modules/document/processing/sentence_splitter.py
+++ b/src/pie_modules/document/processing/sentence_splitter.py
@@ -14,15 +14,15 @@ logger = logging.getLogger(__name__)
 D = TypeVar("D", bound=TextDocumentWithLabeledPartitions)
 
 
-def get_nltk_resource(resource_name: str):
+def get_nltk_resource(resource_name: str, resource_url: str):
     try:
         _create_unverified_https_context = ssl._create_unverified_context
     except AttributeError:
         pass
     else:
         ssl._create_default_https_context = _create_unverified_https_context
-    nltk.download("punkt")
-    return nltk.data.load(resource_name)
+    nltk.download(resource_name)
+    return nltk.data.load(resource_url)
 
 
 class NltkSentenceSplitter:
@@ -45,7 +45,7 @@ class NltkSentenceSplitter:
     ):
         self.partition_layer_name = partition_layer_name
         self.text_field_name = text_field_name
-        self.sentencizer = get_nltk_resource(sentencizer_url)
+        self.sentencizer = get_nltk_resource(resource_name="punbkt", resource_url=sentencizer_url)
 
     def __call__(self, document: D) -> None:
         partition_layer = document[self.partition_layer_name]

--- a/src/pie_modules/document/processing/sentence_splitter.py
+++ b/src/pie_modules/document/processing/sentence_splitter.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import ssl
 from typing import TypeVar
 
 import nltk
@@ -11,6 +12,17 @@ logger = logging.getLogger(__name__)
 
 
 D = TypeVar("D", bound=TextDocumentWithLabeledPartitions)
+
+
+def get_nltk_resource(resource_name: str):
+    try:
+        _create_unverified_https_context = ssl._create_unverified_context
+    except AttributeError:
+        pass
+    else:
+        ssl._create_default_https_context = _create_unverified_https_context
+    nltk.download("punkt")
+    return nltk.data.load(resource_name)
 
 
 class NltkSentenceSplitter:
@@ -33,8 +45,7 @@ class NltkSentenceSplitter:
     ):
         self.partition_layer_name = partition_layer_name
         self.text_field_name = text_field_name
-        nltk.download("punkt")
-        self.sentencizer = nltk.data.load(sentencizer_url)
+        self.sentencizer = get_nltk_resource(sentencizer_url)
 
     def __call__(self, document: D) -> None:
         partition_layer = document[self.partition_layer_name]

--- a/src/pie_modules/document/processing/sentence_splitter.py
+++ b/src/pie_modules/document/processing/sentence_splitter.py
@@ -33,7 +33,7 @@ class NltkSentenceSplitter:
     ):
         self.partition_layer_name = partition_layer_name
         self.text_field_name = text_field_name
-        nltk.download(sentencizer_url)
+        nltk.download("punkt")
         self.sentencizer = nltk.data.load(sentencizer_url)
 
     def __call__(self, document: D) -> None:

--- a/src/pie_modules/document/processing/sentence_splitter.py
+++ b/src/pie_modules/document/processing/sentence_splitter.py
@@ -14,8 +14,9 @@ D = TypeVar("D", bound=TextDocumentWithLabeledPartitions)
 
 
 class NltkSentenceSplitter:
-    """A document processor that splits the text of a document into sentences using the NLTK Punkt
-    tokenizer, see https://www.nltk.org/api/nltk.tokenize.html#nltk.tokenize.punkt.PunktSentenceTokenizer.
+    """A document processor that adds sentence partitions to a TextDocumentWithLabeledPartitions document.
+    It uses the NLTK Punkt tokenizer to split the text of the document into sentences. See
+    https://www.nltk.org/api/nltk.tokenize.html#nltk.tokenize.punkt.PunktSentenceTokenizer for more information.
 
     Args:
         partition_layer_name: The name of the partition layer to add the sentence partitions to. This layer

--- a/src/pie_modules/document/processing/sentence_splitter.py
+++ b/src/pie_modules/document/processing/sentence_splitter.py
@@ -33,6 +33,7 @@ class NltkSentenceSplitter:
     ):
         self.partition_layer_name = partition_layer_name
         self.text_field_name = text_field_name
+        nltk.download(sentencizer_url)
         self.sentencizer = nltk.data.load(sentencizer_url)
 
     def __call__(self, document: D) -> None:

--- a/src/pie_modules/document/processing/sentence_splitter.py
+++ b/src/pie_modules/document/processing/sentence_splitter.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import logging
+from typing import TypeVar
+
+import nltk
+from pytorch_ie.annotations import LabeledSpan
+from pytorch_ie.documents import TextDocumentWithLabeledPartitions
+
+logger = logging.getLogger(__name__)
+
+
+D = TypeVar("D", bound=TextDocumentWithLabeledPartitions)
+
+
+class NltkSentenceSplitter:
+    def __init__(
+        self,
+        partition_layer_name: str = "labeled_partitions",
+        text_field_name: str = "text",
+        sentencizer_url: str = "tokenizers/punkt/PY3/english.pickle",
+    ):
+        self.partition_layer_name = partition_layer_name
+        self.text_field_name = text_field_name
+        self.sentencizer = nltk.data.load(sentencizer_url)
+
+    def __call__(self, document: D) -> None:
+        partition_layer = document[self.partition_layer_name]
+        if len(partition_layer) > 0:
+            logger.warning(
+                f"Layer {self.partition_layer_name} in document {document.id} is not empty. "
+                f"Clearing it before adding new sentence partitions."
+            )
+            partition_layer.clear()
+
+        text: str = getattr(document, self.text_field_name)
+        sentence_spans = self.sentencizer.span_tokenize(text)
+        sentences = [
+            LabeledSpan(start=start, end=end, label="sentence") for start, end in sentence_spans
+        ]
+        partition_layer.extend(sentences)

--- a/tests/document/processing/test_sentence_splitter.py
+++ b/tests/document/processing/test_sentence_splitter.py
@@ -1,7 +1,7 @@
 from pytorch_ie.annotations import LabeledSpan
 from pytorch_ie.documents import TextDocumentWithLabeledPartitions
 
-from pie_modules.document.processing.sentence_splitter import NltkSentenceSplitter
+from pie_modules.document.processing import NltkSentenceSplitter
 
 
 def test_nltk_sentence_splitter(caplog):

--- a/tests/document/processing/test_sentence_splitter.py
+++ b/tests/document/processing/test_sentence_splitter.py
@@ -1,0 +1,27 @@
+from pytorch_ie.annotations import LabeledSpan
+from pytorch_ie.documents import TextDocumentWithLabeledPartitions
+
+from pie_modules.document.processing.sentence_splitter import NltkSentenceSplitter
+
+
+def test_nltk_sentence_splitter(caplog):
+    doc = TextDocumentWithLabeledPartitions(
+        text="This is a test sentence. This is another one.", id="test_doc"
+    )
+    # add a dummy text partition to trigger the warning (see below)
+    doc.labeled_partitions.append(LabeledSpan(start=0, end=len(doc.text), label="text"))
+    caplog.clear()
+    # create the sentence splitter
+    sentence_splitter = NltkSentenceSplitter()
+    # call the sentence splitter
+    sentence_splitter(doc)
+    # check the log message
+    assert len(caplog.records) == 1
+    assert (
+        caplog.records[0].message == "Layer labeled_partitions in document test_doc is not empty. "
+        "Clearing it before adding new sentence partitions."
+    )
+    # check the result
+    assert len(doc.labeled_partitions) == 2
+    assert str(doc.labeled_partitions[0]) == "This is a test sentence."
+    assert str(doc.labeled_partitions[1]) == "This is another one."


### PR DESCRIPTION
This PR adds `pie_modules.document.processing.NltkSentenceSplitter`. From its docstring:

```
A document processor that adds sentence partitions to a TextDocumentWithLabeledPartitions document.
It uses the NLTK Punkt tokenizer to split the text of the document into sentences. See
https://www.nltk.org/api/nltk.tokenize.html#nltk.tokenize.punkt.PunktSentenceTokenizer for more information.

Args:
    partition_layer_name: The name of the partition layer to add the sentence partitions to. This layer
        must be an AnnotationLayer of LabeledSpan annotations.
    text_field_name: The name of the text field in the document to split into sentences.
    sentencizer_url: The URL to the NLTK Punkt tokenizer model.
```