### PR TITLE
`NltkSentenceSplitter` returns the result document

### DIFF
--- a/src/pie_modules/document/processing/sentence_splitter.py
+++ b/src/pie_modules/document/processing/sentence_splitter.py
@@ -24,6 +24,8 @@ class NltkSentenceSplitter:
             must be an AnnotationLayer of LabeledSpan annotations.
         text_field_name: The name of the text field in the document to split into sentences.
         sentencizer_url: The URL to the NLTK Punkt tokenizer model.
+        inplace: A boolean value that determines whether the sentence partitions are added to the input document
+            or a new document is created.
     """
 
     def __init__(
@@ -31,14 +33,19 @@ class NltkSentenceSplitter:
         partition_layer_name: str = "labeled_partitions",
         text_field_name: str = "text",
         sentencizer_url: str = "tokenizers/punkt/PY3/english.pickle",
+        inplace: bool = True,
     ):
         self.partition_layer_name = partition_layer_name
         self.text_field_name = text_field_name
+        self.inplace = inplace
         # download the NLTK Punkt tokenizer model
         nltk.download("punkt")
         self.sentencizer = nltk.data.load(sentencizer_url)
 
-    def __call__(self, document: D) -> None:
+    def __call__(self, document: D) -> D:
+        if not self.inplace:
+            document = document.copy()
+
         partition_layer = document[self.partition_layer_name]
         if len(partition_layer) > 0:
             logger.warning(
@@ -53,3 +60,5 @@ class NltkSentenceSplitter:
             LabeledSpan(start=start, end=end, label="sentence") for start, end in sentence_spans
         ]
         partition_layer.extend(sentences)
+
+        return document

--- a/tests/document/processing/test_sentence_splitter.py
+++ b/tests/document/processing/test_sentence_splitter.py
@@ -1,10 +1,12 @@
+import pytest
 from pytorch_ie.annotations import LabeledSpan
 from pytorch_ie.documents import TextDocumentWithLabeledPartitions
 
 from pie_modules.document.processing import NltkSentenceSplitter
 
 
-def test_nltk_sentence_splitter(caplog):
+@pytest.mark.parametrize("inplace", [True, False])
+def test_nltk_sentence_splitter(caplog, inplace):
     doc = TextDocumentWithLabeledPartitions(
         text="This is a test sentence. This is another one.", id="test_doc"
     )
@@ -12,9 +14,14 @@ def test_nltk_sentence_splitter(caplog):
     doc.labeled_partitions.append(LabeledSpan(start=0, end=len(doc.text), label="text"))
     caplog.clear()
     # create the sentence splitter
-    sentence_splitter = NltkSentenceSplitter()
+    sentence_splitter = NltkSentenceSplitter(inplace=inplace)
     # call the sentence splitter
-    sentence_splitter(doc)
+    result = sentence_splitter(doc)
+    if inplace:
+        assert result is doc
+    else:
+        assert result is not doc
+        doc = result
     # check the log message
     assert len(caplog.records) == 1
     assert (


### PR DESCRIPTION
This PR:
 - adds `inplace` parameter to `NltkSentenceSplitter`; and
 - calling a `NltkSentenceSplitter` returns the result document (independent of `inplace` value).

Note: CI fails because there is currently an issue with https://huggingface.co.