### PR TITLE
fix `RETextClassificationWithIndicesTaskModule` for `NaryRelation`

### DIFF
--- a/src/pie_modules/taskmodules/re_text_classification_with_indices.py
+++ b/src/pie_modules/taskmodules/re_text_classification_with_indices.py
@@ -850,7 +850,7 @@ class RETextClassificationWithIndicesTaskModule(TaskModuleType, ChangesTokenizer
         task_encoding: TaskEncodingType,
     ) -> TargetEncodingType:
         candidate_annotation = task_encoding.metadata["candidate_annotation"]
-        if isinstance(candidate_annotation, BinaryRelation):
+        if isinstance(candidate_annotation, (BinaryRelation, NaryRelation)):
             labels = [candidate_annotation.label]
         else:
             raise NotImplementedError(

--- a/src/pie_modules/taskmodules/re_text_classification_with_indices.py
+++ b/src/pie_modules/taskmodules/re_text_classification_with_indices.py
@@ -854,8 +854,9 @@ class RETextClassificationWithIndicesTaskModule(TaskModuleType, ChangesTokenizer
             labels = [candidate_annotation.label]
         else:
             raise NotImplementedError(
-                f"encoding the target with a candidate_annotation of another type than BinaryRelation is "
-                f"not yet supported. candidate_annotation has the type: {type(candidate_annotation)}"
+                f"encoding the target with a candidate_annotation of another type than BinaryRelation or"
+                f"NaryRelation is not yet supported. candidate_annotation has the type: "
+                f"{type(candidate_annotation)}"
             )
         target = [self.label_to_id[label] for label in labels]
 


### PR DESCRIPTION
`NaryRelation` was not yet allowed in `.encode_target()` 