### PR TITLE
extend statistics for re_classification_with_indices

### DIFF
--- a/src/pie_modules/taskmodules/re_text_classification_with_indices.py
+++ b/src/pie_modules/taskmodules/re_text_classification_with_indices.py
@@ -398,7 +398,9 @@ class RETextClassificationWithIndicesTaskModule(TaskModuleType, ChangesTokenizer
                     axis=1
                 )
             if "used" in to_show.index and "available" in to_show.index:
-                to_show.loc["used %"] = 100 * to_show.loc["used"] / to_show.loc["available"]
+                to_show.loc["used %"] = (
+                    100 * to_show.loc["used"] / to_show.loc["available"]
+                ).round()
             logger.info(f"statistics:\n{to_show.to_markdown()}")
 
     def increase_counter(self, key: Tuple[Any, ...], value: Optional[int] = 1):

--- a/src/pie_modules/taskmodules/re_text_classification_with_indices.py
+++ b/src/pie_modules/taskmodules/re_text_classification_with_indices.py
@@ -397,7 +397,7 @@ class RETextClassificationWithIndicesTaskModule(TaskModuleType, ChangesTokenizer
                 to_show["all_relations"] = to_show.loc[:, to_show.columns != "no_relation"].sum(
                     axis=1
                 )
-            if "used" in to_show.index:
+            if "used" in to_show.index and "available" in to_show.index:
                 to_show.loc["used %"] = 100 * to_show.loc["used"] / to_show.loc["available"]
             logger.info(f"statistics:\n{to_show.to_markdown()}")
 

--- a/src/pie_modules/taskmodules/re_text_classification_with_indices.py
+++ b/src/pie_modules/taskmodules/re_text_classification_with_indices.py
@@ -393,6 +393,12 @@ class RETextClassificationWithIndicesTaskModule(TaskModuleType, ChangesTokenizer
             to_show = pd.Series(self._statistics)
             if len(to_show.index.names) > 1:
                 to_show = to_show.unstack()
+            if to_show.columns.size > 1:
+                to_show["all_relations"] = to_show.loc[:, to_show.columns != "no_relation"].sum(
+                    axis=1
+                )
+            if "used" in to_show.index:
+                to_show.loc["used %"] = 100 * to_show.loc["used"] / to_show.loc["available"]
             logger.info(f"statistics:\n{to_show.to_markdown()}")
 
     def increase_counter(self, key: Tuple[Any, ...], value: Optional[int] = 1):

--- a/tests/taskmodules/test_re_text_classification_with_indices.py
+++ b/tests/taskmodules/test_re_text_classification_with_indices.py
@@ -1552,10 +1552,21 @@ def test_encode_with_collect_statistics(documents, caplog):
 
     assert len(caplog.messages) == 1
     expected_message = "statistics:\n"
-    expected_message += "|           |   org:founded_by |   per:employee_of |   per:founder |\n"
-    expected_message += "|:----------|-----------------:|------------------:|--------------:|\n"
-    expected_message += "| available |                2 |                 3 |             2 |\n"
-    expected_message += "| used      |                2 |                 3 |             2 |"
+    expected_message += (
+        "|           |   org:founded_by |   per:employee_of |   per:founder |   all_relations |\n"
+    )
+    expected_message += (
+        "|:----------|-----------------:|------------------:|--------------:|----------------:|\n"
+    )
+    expected_message += (
+        "| available |                2 |                 3 |             2 |               7 |\n"
+    )
+    expected_message += (
+        "| used      |                2 |                 3 |             2 |               7 |\n"
+    )
+    expected_message += (
+        "| used %    |              100 |               100 |           100 |             100 |"
+    )
     assert caplog.messages[0] == expected_message
 
 

--- a/tests/taskmodules/test_re_text_classification_with_indices.py
+++ b/tests/taskmodules/test_re_text_classification_with_indices.py
@@ -1551,23 +1551,14 @@ def test_encode_with_collect_statistics(documents, caplog):
     assert len(task_encodings) == 7
 
     assert len(caplog.messages) == 1
-    expected_message = "statistics:\n"
-    expected_message += (
+    assert caplog.messages[0] == (
+        "statistics:\n"
         "|           |   org:founded_by |   per:employee_of |   per:founder |   all_relations |\n"
-    )
-    expected_message += (
         "|:----------|-----------------:|------------------:|--------------:|----------------:|\n"
-    )
-    expected_message += (
         "| available |                2 |                 3 |             2 |               7 |\n"
-    )
-    expected_message += (
         "| used      |                2 |                 3 |             2 |               7 |\n"
-    )
-    expected_message += (
         "| used %    |              100 |               100 |           100 |             100 |"
     )
-    assert caplog.messages[0] == expected_message
 
 
 def test_configure_model_metric(documents, taskmodule):


### PR DESCRIPTION
New output:
- add `all_relations` column with summary (only if there is more then 1 relation type in a table). note that we exclude the `no_relations`
- add `used %` row (only if `used` row exists)

Example:
```md
|           |   org:founded_by |   per:employee_of |   per:founder |   all_relations |
|:----------|-----------------:|------------------:|--------------:|----------------:|
| available |                2 |                 3 |             2 |               7 |
| used      |                2 |                 3 |             2 |               7 |
| used %    |              100 |               100 |           100 |             100 |
```