### PR TITLE
tokenization saves a mapping from original to new annotations in `added_annotations`

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2040,4 +2040,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "71ac3e36e1b0a7b2a01b34364d179a548a4502674695fc854c4097d2984cb133"
+content-hash = "40d0051cd6b7c9c2da0d7478dca5632634d08c47c2f71accb6c672d97f23f6b7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.9"
-pytorch-ie = ">=0.30.3,<0.32.0"
+pytorch-ie = ">=0.31.0,<0.32.0"
 pytorch-lightning = "^2.1.0"
 torchmetrics = "^1"
 pytorch-crf = ">=0.7.2"

--- a/src/pie_modules/document/processing/tokenization.py
+++ b/src/pie_modules/document/processing/tokenization.py
@@ -124,6 +124,32 @@ def text_based_document_to_token_based(
     verbose: bool = True,
     added_annotations: Optional[Dict[str, Dict[Annotation, Annotation]]] = None,
 ) -> ToD:
+    """Convert a text based document to a token based document. Uses either tokens,
+    token_offset_mapping or char_to_token (provided explicitly or from the document metadata) to
+    convert the annotations that target the text and all that depend on these (also adds all
+    remaining annotations).
+
+    Args:
+        doc (TextBasedDocument): The text based document.
+        result_document_type (Union[Type[ToD], str]): The type of the token based document.
+        tokens (Optional[List[str]], optional): The tokens. If None, the tokens are taken from the
+            metadata. Defaults to None.
+        token_offset_mapping (Optional[List[Tuple[int, int]]], optional): The token offset mapping.
+            If None, the token offset mapping is taken from the metadata. Defaults to None.
+        char_to_token (Optional[Callable[[int], Optional[int]]], optional): The char to token function.
+            If None, the char to token function is constructed from the token offset mapping. Defaults
+            to None.
+        strict_span_conversion (bool, optional): If True, raise an error if not all annotations can
+            be converted to token based documents. Defaults to True.
+        verbose (bool, optional): If True, log warnings if annotations can not be converted. Defaults
+            to True.
+        added_annotations (Optional[Dict[str, Dict[Annotation, Annotation]]], optional): Pass an empty
+            dictionary to collect the added annotations. Defaults to None.
+
+    Returns:
+        ToD: The token based document of type result_document_type with the converted annotations.
+    """
+
     document_type = resolve_type(
         type_or_str=result_document_type, expected_super_type=TokenBasedDocument
     )
@@ -246,6 +272,33 @@ def token_based_document_to_text_based(
     verbose: bool = True,
     added_annotations: Optional[Dict[str, Dict[Annotation, Annotation]]] = None,
 ) -> TeD:
+    """Convert a token based document to a text based document. Uses either text,
+    token_offset_mapping or char_to_token (provided explicitly or from the document metadata) to
+    convert the annotations that target the tokens and all that depend on these (also adds all
+    remaining annotations).
+
+    Args:
+        doc (TokenBasedDocument): The token based document.
+        result_document_type (Union[Type[TeD], str]): The type of the text based document.
+        text (Optional[str], optional): The text. If None, constructed from the tokens (requires
+            join_tokens_with) or taken from the metadata. Defaults to None.
+        token_offset_mapping (Optional[List[Tuple[int, int]]], optional): The token offset mapping.
+            If None, the token offset mapping is constructed from the tokens (requires join_tokens_with)
+            or taken from the metadata. Defaults to None.
+        join_tokens_with (Optional[str], optional): The token separator. If no text is provided, the
+            text and token offset mapping are constructed from the tokens by joining them with this
+            separator. Defaults to None.
+        strict_span_conversion (bool, optional): If True, raise an error if not all annotations
+            can be converted to text based documents. Defaults to True.
+        verbose (bool, optional): If True, log warnings if annotations can not be converted.
+            Defaults to True.
+        added_annotations (Optional[Dict[str, Dict[Annotation, Annotation]]], optional): Pass an
+            empty dictionary to collect the added annotations. Defaults to None.
+
+    Returns:
+        TeD: The text based document of type result_document_type with the converted annotations.
+    """
+
     document_type = resolve_type(
         type_or_str=result_document_type, expected_super_type=TextBasedDocument
     )
@@ -342,6 +395,27 @@ def tokenize_document(
     verbose: bool = True,
     **tokenize_kwargs,
 ) -> List[ToD]:
+    """Tokenize a document with a given tokenizer and return a list of token based documents. The
+    document is tokenized in partitions if a partition layer is provided. The annotations that
+    target the text are converted to target the tokens and also all dependent annotations are
+    converted.
+
+    Args:
+        doc (TextBasedDocument): The document to tokenize.
+        tokenizer (PreTrainedTokenizer): The tokenizer.
+        result_document_type (Type[ToD]): The exact type of the token based documents.
+        partition_layer (Optional[str], optional): The layer to use for partitioning the document. If None, the whole
+            document is tokenized. Defaults to None.
+        strict_span_conversion (bool, optional): If True, raise an error if not all annotations can be converted to
+            token based documents. Defaults to True.
+        added_annotations (Optional[List[Dict[str, Dict[Annotation, Annotation]]]], optional): Pass an empty list to
+            collect the added annotations. Defaults to None.
+        verbose (bool, optional): If True, log warnings if annotations can not be converted. Defaults to True.
+
+    Returns:
+        List[ToD]: The token based documents of type result_document_type with the converted annotations.
+    """
+
     added_annotation_lists: Dict[str, List[Annotation]] = defaultdict(list)
     result = []
     partitions: Iterable[Span]

--- a/src/pie_modules/document/processing/tokenization.py
+++ b/src/pie_modules/document/processing/tokenization.py
@@ -216,7 +216,9 @@ def text_based_document_to_token_based(
             else:
                 override_annotations[text_targeting_layer_name][char_span._id] = token_span
                 if added_annotations is not None:
-                    added_annotations[text_targeting_layer_name][char_span] = token_span
+                    added_annotations.setdefault(text_targeting_layer_name, {})[
+                        char_span
+                    ] = token_span
         valid_spans = set(override_annotations[text_targeting_layer_name].values())
         result[text_targeting_layer_name].extend(sorted(valid_spans, key=span_sort_key))
 
@@ -228,8 +230,8 @@ def text_based_document_to_token_based(
         verbose=verbose,
     )
     if added_annotations is not None:
-        for layer_name, annotations in added_annotations_from_remaining_layers.items():
-            added_annotations[layer_name].update(annotations)
+        for layer_name, annotation_mapping in added_annotations_from_remaining_layers.items():
+            added_annotations.setdefault(layer_name, {}).update(annotation_mapping)
 
     return result
 
@@ -310,7 +312,9 @@ def token_based_document_to_text_based(
             char_span = token_span_to_char_span(token_span, token_offset_mapping)
             override_annotations[token_targeting_layer_name][token_span._id] = char_span
             if added_annotations is not None:
-                added_annotations[token_targeting_layer_name][token_span] = char_span
+                added_annotations.setdefault(token_targeting_layer_name, {})[
+                    token_span
+                ] = char_span
         valid_spans = set(override_annotations[token_targeting_layer_name].values())
         result[token_targeting_layer_name].extend(sorted(valid_spans, key=span_sort_key))
 
@@ -322,8 +326,8 @@ def token_based_document_to_text_based(
         verbose=verbose,
     )
     if added_annotations is not None:
-        for layer_name, annotations in added_annotations_from_remaining_layers.items():
-            added_annotations[layer_name].update(annotations)
+        for layer_name, annotation_mapping in added_annotations_from_remaining_layers.items():
+            added_annotations.setdefault(layer_name, {}).update(annotation_mapping)
 
     return result
 

--- a/src/pie_modules/document/processing/tokenization.py
+++ b/src/pie_modules/document/processing/tokenization.py
@@ -338,10 +338,11 @@ def tokenize_document(
     result_document_type: Type[ToD],
     partition_layer: Optional[str] = None,
     strict_span_conversion: bool = True,
+    added_annotations: Optional[List[Dict[str, Dict[Annotation, Annotation]]]] = None,
     verbose: bool = True,
     **tokenize_kwargs,
 ) -> List[ToD]:
-    added_annotations: Dict[str, List[Annotation]] = defaultdict(list)
+    added_annotation_lists: Dict[str, List[Annotation]] = defaultdict(list)
     result = []
     partitions: Iterable[Span]
     if partition_layer is None:
@@ -388,7 +389,9 @@ def tokenize_document(
             tokenized_document.metadata["tokenizer_encoding"] = batch_encoding
             result.append(tokenized_document)
             for k, v in current_added_annotations.items():
-                added_annotations[k].extend(v)
+                added_annotation_lists[k].extend(v)
+            if added_annotations is not None:
+                added_annotations.append(current_added_annotations)
 
     missed_annotations = defaultdict(set)
     if strict_span_conversion or verbose:
@@ -400,7 +403,7 @@ def tokenize_document(
             # and entries get quite probably removed when windowing is applied, so this just pollutes the logs
             if annotation_field.name != partition_layer:
                 current_missed_annotations = set(doc[annotation_field.name]) - set(
-                    added_annotations[annotation_field.name]
+                    added_annotation_lists[annotation_field.name]
                 )
                 if len(current_missed_annotations) > 0:
                     missed_annotations[annotation_field.name] = current_missed_annotations


### PR DESCRIPTION
This PR does the following:
 - `text_based_document_to_token_based()` and `token_based_document_to_text_based()` save dicts in `added_annotations` (instead of just the list of original ones that got handled)
 - add a parameter `added_annotations` to `tokenize_document` (works similar as in `text_based_document_to_token_based()` and `token_based_document_to_text_based()`)
 - add documentation to all three methods

Note: This requires `pytorch-ie>=0.31.0` because of https://github.com/ArneBinder/pytorch-ie/pull/418, so this is a breaking change.