### PR TITLE
fix taskmodule metrics (`ignore_index`)

### DIFF
--- a/src/pie_modules/taskmodules/labeled_span_extraction_by_token_classification.py
+++ b/src/pie_modules/taskmodules/labeled_span_extraction_by_token_classification.py
@@ -34,7 +34,7 @@ from pytorch_ie.documents import (
 )
 from pytorch_ie.utils.span import bio_tags_to_spans
 from tokenizers import Encoding
-from torchmetrics import F1Score, Metric, MetricCollection
+from torchmetrics import F1Score, Metric, MetricCollection, Precision, Recall
 from transformers import AutoTokenizer
 from typing_extensions import TypeAlias
 
@@ -250,9 +250,9 @@ class LabeledSpanExtractionByTokenClassificationTaskModule(TaskModuleType):
             casted_document,
             tokenizer=self.tokenizer,
             result_document_type=tokenized_document_type,
-            partition_layer="labeled_partitions"
-            if self.partition_annotation is not None
-            else None,
+            partition_layer=(
+                "labeled_partitions" if self.partition_annotation is not None else None
+            ),
             strict_span_conversion=False,
             **self.tokenize_kwargs,
         )
@@ -416,6 +416,22 @@ class LabeledSpanExtractionByTokenClassificationTaskModule(TaskModuleType):
                 ),
                 "token/micro/f1": WrappedMetricWithPrepareFunction(
                     metric=F1Score(average="micro", **common_metric_kwargs),
+                    prepare_function=_get_label_ids_from_model_output,
+                ),
+                "token/macro/precision": WrappedMetricWithPrepareFunction(
+                    metric=Precision(average="macro", **common_metric_kwargs),
+                    prepare_function=_get_label_ids_from_model_output,
+                ),
+                "token/macro/recall": WrappedMetricWithPrepareFunction(
+                    metric=Recall(average="macro", **common_metric_kwargs),
+                    prepare_function=_get_label_ids_from_model_output,
+                ),
+                "token/micro/precision": WrappedMetricWithPrepareFunction(
+                    metric=Precision(average="micro", **common_metric_kwargs),
+                    prepare_function=_get_label_ids_from_model_output,
+                ),
+                "token/micro/recall": WrappedMetricWithPrepareFunction(
+                    metric=Recall(average="micro", **common_metric_kwargs),
                     prepare_function=_get_label_ids_from_model_output,
                 ),
             }

--- a/src/pie_modules/taskmodules/labeled_span_extraction_by_token_classification.py
+++ b/src/pie_modules/taskmodules/labeled_span_extraction_by_token_classification.py
@@ -87,13 +87,10 @@ TaskModuleType: TypeAlias = TaskModule[
 logger = logging.getLogger(__name__)
 
 
-def remove_label_pad_ids(model_output: ModelOutputType, label_pad_id: int) -> torch.LongTensor:
-    labels = model_output["labels"]
-    # remove the special tokens and padding from the predicted / target labels
-    # because the label_pad_id is usually not a valid index (e.g. -100)
-    mask = labels != label_pad_id
-    labels_valid = labels[mask]
-    return labels_valid
+def _get_label_ids_from_model_output(
+    model_output: ModelTargetType,
+) -> torch.LongTensor:
+    return model_output["labels"]
 
 
 def unbatch_and_decode_annotations(
@@ -409,17 +406,17 @@ class LabeledSpanExtractionByTokenClassificationTaskModule(TaskModuleType):
         common_metric_kwargs = {
             "num_classes": len(self.label_to_id),
             "task": "multiclass",
-            "ignore_index": self.label_to_id["O"],
+            "ignore_index": self.label_pad_id,
         }
         token_scores = MetricCollection(
             {
                 "token/macro/f1": WrappedMetricWithPrepareFunction(
                     metric=F1Score(average="macro", **common_metric_kwargs),
-                    prepare_function=partial(remove_label_pad_ids, label_pad_id=self.label_pad_id),
+                    prepare_function=_get_label_ids_from_model_output,
                 ),
                 "token/micro/f1": WrappedMetricWithPrepareFunction(
                     metric=F1Score(average="micro", **common_metric_kwargs),
-                    prepare_function=partial(remove_label_pad_ids, label_pad_id=self.label_pad_id),
+                    prepare_function=_get_label_ids_from_model_output,
                 ),
             }
         )

--- a/src/pie_modules/taskmodules/re_text_classification_with_indices.py
+++ b/src/pie_modules/taskmodules/re_text_classification_with_indices.py
@@ -991,7 +991,6 @@ class RETextClassificationWithIndicesTaskModule(TaskModuleType, ChangesTokenizer
         common_metric_kwargs = {
             "num_classes": len(labels),
             "task": "multilabel" if self.multi_label else "multiclass",
-            "ignore_index": self.label_to_id[self.none_label],
         }
         return WrappedMetricWithPrepareFunction(
             metric=MetricCollection(

--- a/tests/models/test_simple_token_classification.py
+++ b/tests/models/test_simple_token_classification.py
@@ -343,6 +343,10 @@ def test_validation_step_and_on_epoch_end(batch, model, config):
         "span/micro/recall": 0.0,
         "token/macro/f1": 0.0,
         "token/micro/f1": 0.0,
+        "token/macro/precision": 0.0,
+        "token/macro/recall": 0.0,
+        "token/micro/precision": 0.0,
+        "token/micro/recall": 0.0,
     }
 
     model.on_validation_epoch_end()
@@ -370,6 +374,10 @@ def test_test_step_and_on_epoch_end(batch, model, config):
         "span/micro/recall": 0.0,
         "token/macro/f1": 0.0,
         "token/micro/f1": 0.0,
+        "token/macro/precision": 0.0,
+        "token/macro/recall": 0.0,
+        "token/micro/precision": 0.0,
+        "token/micro/recall": 0.0,
     }
 
     model.on_test_epoch_end()

--- a/tests/models/test_token_classification_with_seq2seq_encoder_and_crf.py
+++ b/tests/models/test_token_classification_with_seq2seq_encoder_and_crf.py
@@ -416,6 +416,10 @@ def test_validation_step_and_on_epoch_end(batch, model, config):
         assert metric_values == {
             "token/macro/f1": 0.20666667819023132,
             "token/micro/f1": 0.2068965584039688,
+            "token/macro/precision": 0.29019609093666077,
+            "token/macro/recall": 0.2666666805744171,
+            "token/micro/precision": 0.2068965584039688,
+            "token/micro/recall": 0.2068965584039688,
             "span/ORG/f1": 0.3636363744735718,
             "span/ORG/recall": 0.25,
             "span/ORG/precision": 0.6666666865348816,
@@ -434,6 +438,10 @@ def test_validation_step_and_on_epoch_end(batch, model, config):
         assert metric_values == {
             "token/macro/f1": 0.11717171967029572,
             "token/micro/f1": 0.17241379618644714,
+            "token/macro/precision": 0.22500000894069672,
+            "token/macro/recall": 0.24444444477558136,
+            "token/micro/precision": 0.17241379618644714,
+            "token/micro/recall": 0.17241379618644714,
             "span/ORG/f1": 0.0,
             "span/ORG/recall": 0.0,
             "span/ORG/precision": 0.0,
@@ -464,6 +472,10 @@ def test_test_step_and_on_epoch_end(batch, model, config):
         assert metric_values == {
             "token/macro/f1": 0.20666667819023132,
             "token/micro/f1": 0.2068965584039688,
+            "token/macro/precision": 0.29019609093666077,
+            "token/macro/recall": 0.2666666805744171,
+            "token/micro/precision": 0.2068965584039688,
+            "token/micro/recall": 0.2068965584039688,
             "span/ORG/f1": 0.3636363744735718,
             "span/ORG/recall": 0.25,
             "span/ORG/precision": 0.6666666865348816,
@@ -482,6 +494,10 @@ def test_test_step_and_on_epoch_end(batch, model, config):
         assert metric_values == {
             "token/macro/f1": 0.11717171967029572,
             "token/micro/f1": 0.17241379618644714,
+            "token/macro/precision": 0.22500000894069672,
+            "token/macro/recall": 0.24444444477558136,
+            "token/micro/precision": 0.17241379618644714,
+            "token/micro/recall": 0.17241379618644714,
             "span/ORG/f1": 0.0,
             "span/ORG/recall": 0.0,
             "span/ORG/precision": 0.0,

--- a/tests/models/test_token_classification_with_seq2seq_encoder_and_crf.py
+++ b/tests/models/test_token_classification_with_seq2seq_encoder_and_crf.py
@@ -414,8 +414,8 @@ def test_validation_step_and_on_epoch_end(batch, model, config):
     if config == {}:
         torch.testing.assert_close(loss, torch.tensor(77.59623718261719))
         assert metric_values == {
-            "token/macro/f1": 0.3361110985279083,
-            "token/micro/f1": 0.4000000059604645,
+            "token/macro/f1": 0.20666667819023132,
+            "token/micro/f1": 0.2068965584039688,
             "span/ORG/f1": 0.3636363744735718,
             "span/ORG/recall": 0.25,
             "span/ORG/precision": 0.6666666865348816,
@@ -432,20 +432,20 @@ def test_validation_step_and_on_epoch_end(batch, model, config):
     elif config == {"use_crf": False}:
         torch.testing.assert_close(loss, torch.tensor(1.9865683317184448))
         assert metric_values == {
-            "token/macro/f1": 0.2545454502105713,
-            "token/micro/f1": 0.3333333432674408,
-            "span/PER/f1": 0.0,
-            "span/PER/recall": 0.0,
-            "span/PER/precision": 0.0,
+            "token/macro/f1": 0.11717171967029572,
+            "token/micro/f1": 0.17241379618644714,
             "span/ORG/f1": 0.0,
             "span/ORG/recall": 0.0,
             "span/ORG/precision": 0.0,
-            "span/macro/f1": 0.0,
-            "span/macro/precision": 0.0,
-            "span/macro/recall": 0.0,
+            "span/PER/f1": 0.0,
+            "span/PER/recall": 0.0,
+            "span/PER/precision": 0.0,
             "span/micro/f1": 0.0,
             "span/micro/recall": 0.0,
             "span/micro/precision": 0.0,
+            "span/macro/f1": 0.0,
+            "span/macro/recall": 0.0,
+            "span/macro/precision": 0.0,
         }
     else:
         raise ValueError(f"Unknown config: {config}")
@@ -462,14 +462,14 @@ def test_test_step_and_on_epoch_end(batch, model, config):
     if config == {}:
         torch.testing.assert_close(loss, torch.tensor(77.59623718261719))
         assert metric_values == {
-            "token/macro/f1": 0.3361110985279083,
-            "token/micro/f1": 0.4000000059604645,
-            "span/PER/f1": 0.0,
-            "span/PER/recall": 0.0,
-            "span/PER/precision": 0.0,
+            "token/macro/f1": 0.20666667819023132,
+            "token/micro/f1": 0.2068965584039688,
             "span/ORG/f1": 0.3636363744735718,
             "span/ORG/recall": 0.25,
             "span/ORG/precision": 0.6666666865348816,
+            "span/PER/f1": 0.0,
+            "span/PER/recall": 0.0,
+            "span/PER/precision": 0.0,
             "span/micro/f1": 0.12121212482452393,
             "span/micro/recall": 0.07407407462596893,
             "span/micro/precision": 0.3333333432674408,
@@ -480,20 +480,20 @@ def test_test_step_and_on_epoch_end(batch, model, config):
     elif config == {"use_crf": False}:
         torch.testing.assert_close(loss, torch.tensor(1.9865683317184448))
         assert metric_values == {
-            "token/macro/f1": 0.2545454502105713,
-            "token/micro/f1": 0.3333333432674408,
+            "token/macro/f1": 0.11717171967029572,
+            "token/micro/f1": 0.17241379618644714,
             "span/ORG/f1": 0.0,
             "span/ORG/recall": 0.0,
             "span/ORG/precision": 0.0,
             "span/PER/f1": 0.0,
             "span/PER/recall": 0.0,
             "span/PER/precision": 0.0,
-            "span/macro/f1": 0.0,
-            "span/macro/precision": 0.0,
-            "span/macro/recall": 0.0,
             "span/micro/f1": 0.0,
             "span/micro/recall": 0.0,
             "span/micro/precision": 0.0,
+            "span/macro/f1": 0.0,
+            "span/macro/recall": 0.0,
+            "span/macro/precision": 0.0,
         }
     else:
         raise ValueError(f"Unknown config: {config}")

--- a/tests/taskmodules/test_labeled_span_extraction_by_token_classification.py
+++ b/tests/taskmodules/test_labeled_span_extraction_by_token_classification.py
@@ -755,7 +755,14 @@ def test_configure_model_metric(documents):
 
     metric = taskmodule.configure_model_metric(stage="test")
     values = metric.compute()
-    assert values == {"token/macro/f1": tensor(0.0), "token/micro/f1": tensor(0.0)}
+    assert values == {
+        "token/macro/f1": tensor(0.0),
+        "token/micro/f1": tensor(0.0),
+        "token/macro/precision": tensor(0.0),
+        "token/macro/recall": tensor(0.0),
+        "token/micro/precision": tensor(0.0),
+        "token/micro/recall": tensor(0.0),
+    }
 
     batch = taskmodule.collate(taskmodule.encode(documents, encode_target=True))
     targets = batch[1]
@@ -776,6 +783,10 @@ def test_configure_model_metric(documents):
         "span/micro/recall": tensor(1.0),
         "token/macro/f1": tensor(1.0),
         "token/micro/f1": tensor(1.0),
+        "token/macro/precision": tensor(1.0),
+        "token/macro/recall": tensor(1.0),
+        "token/micro/precision": tensor(1.0),
+        "token/micro/recall": tensor(1.0),
     }
 
     target_labels = targets["labels"]
@@ -789,6 +800,10 @@ def test_configure_model_metric(documents):
     assert values_converted == {
         "token/macro/f1": 0.5434783101081848,
         "token/micro/f1": 0.5249999761581421,
+        "token/macro/precision": 0.773809552192688,
+        "token/macro/recall": 0.625,
+        "token/micro/precision": 0.5249999761581421,
+        "token/micro/recall": 0.5249999761581421,
         "span/LOC/recall": 0.0476190485060215,
         "span/LOC/precision": 0.5,
         "span/LOC/f1": 0.08695652335882187,

--- a/tests/taskmodules/test_labeled_span_extraction_by_token_classification.py
+++ b/tests/taskmodules/test_labeled_span_extraction_by_token_classification.py
@@ -787,8 +787,8 @@ def test_configure_model_metric(documents):
     values = metric.compute()
     values_converted = {k: v.item() for k, v in values.items()}
     assert values_converted == {
-        "token/macro/f1": 0.6349206566810608,
-        "token/micro/f1": 0.625,
+        "token/macro/f1": 0.5434783101081848,
+        "token/micro/f1": 0.5249999761581421,
         "span/LOC/recall": 0.0476190485060215,
         "span/LOC/precision": 0.5,
         "span/LOC/f1": 0.08695652335882187,


### PR DESCRIPTION
Originally, we use the id of `no_relation` (relation extraction) or `O` (token classification) as `ignore_index`. However, this disrespects all errors where the model predicts a valid class (not  `no_relation` / `O`), but the gold data is actually `no_relation` / `O` because using them as ignore_index simply masks away all entries where the gold data has the respective index. This PR changes that behavior by not setting ignore_index to these values (we set it just to the padding indices which really indicate invalid values for gold *and* predictions). Note that this may produce quite high micro values because there are in general a lot of `no_relation` / `O`.

affected taskmodules: 
 - `LabeledSpanExtractionByTokenClassificationTaskModule` 
 - `RETextClassificationWithIndicesTaskModule`