### PR TITLE
`enforce_same_original_doc_id` parameter & improved text pair metadata

### DIFF
--- a/src/pie_modules/document/processing/text_pair.py
+++ b/src/pie_modules/document/processing/text_pair.py
@@ -92,6 +92,7 @@ def _construct_text_pair_coref_documents_from_partitions_via_relations(
                 text_pair=text_pair,
                 metadata={
                     "original_doc_id": document.id,
+                    "original_doc_id_pair": document.id,
                     "span": {"start": head_partition.start, "end": head_partition.end},
                     "span_pair": {"start": tail_partition.start, "end": tail_partition.end},
                 },

--- a/src/pie_modules/document/processing/text_pair.py
+++ b/src/pie_modules/document/processing/text_pair.py
@@ -93,8 +93,11 @@ def _construct_text_pair_coref_documents_from_partitions_via_relations(
                 metadata={
                     "original_doc_id": document.id,
                     "original_doc_id_pair": document.id,
-                    "original_span": {"start": head_partition.start, "end": head_partition.end},
-                    "original_span_pair": {
+                    "original_doc_span": {
+                        "start": head_partition.start,
+                        "end": head_partition.end,
+                    },
+                    "original_doc_span_pair": {
                         "start": tail_partition.start,
                         "end": tail_partition.end,
                     },
@@ -212,8 +215,8 @@ def add_negative_coref_relations(
             positive_tuples[(doc.text_pair, doc.text)].add((coref.tail.copy(), coref.head.copy()))
         text2original_doc_id[doc.text] = doc.metadata.get("original_doc_id")
         text2original_doc_id[doc.text_pair] = doc.metadata.get("original_doc_id_pair")
-        text2span[doc.text] = doc.metadata.get("original_span")
-        text2span[doc.text_pair] = doc.metadata.get("original_span_pair")
+        text2span[doc.text] = doc.metadata.get("original_doc_span")
+        text2span[doc.text_pair] = doc.metadata.get("original_doc_span_pair")
 
     new_docs = []
     new_rels2new_docs = {}
@@ -237,8 +240,8 @@ def add_negative_coref_relations(
                 metadata={
                     "original_doc_id": original_doc_id,
                     "original_doc_id_pair": original_doc_id_pair,
-                    "original_span": text2span[text],
-                    "original_span_pair": text2span[text_pair],
+                    "original_doc_span": text2span[text],
+                    "original_doc_span_pair": text2span[text_pair],
                 },
             )
             new_doc.labeled_spans.extend(labeled_span.copy() for labeled_span in text2spans[text])

--- a/src/pie_modules/document/processing/text_pair.py
+++ b/src/pie_modules/document/processing/text_pair.py
@@ -93,8 +93,11 @@ def _construct_text_pair_coref_documents_from_partitions_via_relations(
                 metadata={
                     "original_doc_id": document.id,
                     "original_doc_id_pair": document.id,
-                    "span": {"start": head_partition.start, "end": head_partition.end},
-                    "span_pair": {"start": tail_partition.start, "end": tail_partition.end},
+                    "original_span": {"start": head_partition.start, "end": head_partition.end},
+                    "original_span_pair": {
+                        "start": tail_partition.start,
+                        "end": tail_partition.end,
+                    },
                 },
             )
 
@@ -209,8 +212,8 @@ def add_negative_coref_relations(
             positive_tuples[(doc.text_pair, doc.text)].add((coref.tail.copy(), coref.head.copy()))
         text2original_doc_id[doc.text] = doc.metadata.get("original_doc_id")
         text2original_doc_id[doc.text_pair] = doc.metadata.get("original_doc_id_pair")
-        text2span[doc.text] = doc.metadata.get("span")
-        text2span[doc.text_pair] = doc.metadata.get("span_pair")
+        text2span[doc.text] = doc.metadata.get("original_span")
+        text2span[doc.text_pair] = doc.metadata.get("original_span_pair")
 
     new_docs = []
     new_rels2new_docs = {}
@@ -234,8 +237,8 @@ def add_negative_coref_relations(
                 metadata={
                     "original_doc_id": original_doc_id,
                     "original_doc_id_pair": original_doc_id_pair,
-                    "span": text2span[text],
-                    "span_pair": text2span[text_pair],
+                    "original_span": text2span[text],
+                    "original_span_pair": text2span[text_pair],
                 },
             )
             new_doc.labeled_spans.extend(labeled_span.copy() for labeled_span in text2spans[text])

--- a/src/pie_modules/document/processing/text_pair.py
+++ b/src/pie_modules/document/processing/text_pair.py
@@ -207,10 +207,10 @@ def add_negative_coref_relations(
         for coref in doc.binary_coref_relations:
             positive_tuples[(doc.text, doc.text_pair)].add((coref.head.copy(), coref.tail.copy()))
             positive_tuples[(doc.text_pair, doc.text)].add((coref.tail.copy(), coref.head.copy()))
-        text2original_doc_id[doc.text] = doc.metadata["original_doc_id"]
-        text2original_doc_id[doc.text_pair] = doc.metadata["original_doc_id_pair"]
-        text2span[doc.text] = doc.metadata["span"]
-        text2span[doc.text_pair] = doc.metadata["span_pair"]
+        text2original_doc_id[doc.text] = doc.metadata.get("original_doc_id")
+        text2original_doc_id[doc.text_pair] = doc.metadata.get("original_doc_id_pair")
+        text2span[doc.text] = doc.metadata.get("span")
+        text2span[doc.text_pair] = doc.metadata.get("span_pair")
 
     new_docs = []
     new_rels2new_docs = {}
@@ -220,8 +220,13 @@ def add_negative_coref_relations(
         original_doc_id = text2original_doc_id[text]
         for text_pair in sorted(text2spans):
             original_doc_id_pair = text2original_doc_id[text_pair]
-            if enforce_same_original_doc_id and original_doc_id != original_doc_id_pair:
-                continue
+            if enforce_same_original_doc_id:
+                if original_doc_id is None or original_doc_id_pair is None:
+                    raise ValueError(
+                        "enforce_same_original_doc_id is set, but original_doc_id(_pair) is None"
+                    )
+                if original_doc_id != original_doc_id_pair:
+                    continue
             current_positives = positive_tuples.get((text, text_pair), set())
             new_doc = TextPairDocumentWithLabeledSpansAndBinaryCorefRelations(
                 text=text,

--- a/src/pie_modules/document/processing/text_pair.py
+++ b/src/pie_modules/document/processing/text_pair.py
@@ -87,7 +87,14 @@ def _construct_text_pair_coref_documents_from_partitions_via_relations(
             else:
                 doc_id = None
             new_doc = TextPairDocumentWithLabeledSpansAndBinaryCorefRelations(
-                id=doc_id, text=text, text_pair=text_pair
+                id=doc_id,
+                text=text,
+                text_pair=text_pair,
+                metadata={
+                    "original_doc_id": document.id,
+                    "span": {"start": head_partition.start, "end": head_partition.end},
+                    "span_pair": {"start": tail_partition.start, "end": tail_partition.end},
+                },
             )
 
             head_spans_mapping = {

--- a/tests/document/processing/test_text_pair.py
+++ b/tests/document/processing/test_text_pair.py
@@ -137,6 +137,9 @@ def test_construct_text_pair_coref_documents_from_partitions_via_relations(text_
     assert set(all_docs) == {"doc2[0:18]+doc2[19:36]", "doc1[0:20]+doc1[21:39]"}
 
     doc = all_docs["doc2[0:18]+doc2[19:36]"]
+    assert doc.metadata["original_doc_id"] == "doc2"
+    assert doc.metadata["span"] == {"end": 18, "start": 0}
+    assert doc.metadata["span_pair"] == {"end": 36, "start": 19}
     assert doc.text == "Bob loves his cat."
     assert doc.text_pair == "She sleeps a lot."
     assert doc.labeled_spans.resolve() == [("PERSON", "Bob"), ("ANIMAL", "his cat")]
@@ -146,6 +149,9 @@ def test_construct_text_pair_coref_documents_from_partitions_via_relations(text_
     ]
 
     doc = all_docs["doc1[0:20]+doc1[21:39]"]
+    assert doc.metadata["original_doc_id"] == "doc1"
+    assert doc.metadata["span"] == {"end": 20, "start": 0}
+    assert doc.metadata["span_pair"] == {"end": 39, "start": 21}
     assert doc.text == "Entity A works at B."
     assert doc.text_pair == "And she founded C."
     assert doc.labeled_spans.resolve() == [("PERSON", "Entity A"), ("COMPANY", "B")]
@@ -158,7 +164,10 @@ def test_construct_text_pair_coref_documents_from_partitions_via_relations(text_
 @pytest.fixture(scope="module")
 def positive_documents():
     doc1 = TextPairDocumentWithLabeledSpansAndBinaryCorefRelations(
-        id="0", text="Entity A works at B.", text_pair="And she founded C."
+        id="0",
+        text="Entity A works at B.",
+        text_pair="And she founded C.",
+        metadata={"original_doc_id": "doc1"},
     )
     doc1.labeled_spans.append(LabeledSpan(start=0, end=8, label="PERSON"))
     doc1.labeled_spans.append(LabeledSpan(start=18, end=19, label="COMPANY"))
@@ -169,7 +178,10 @@ def positive_documents():
     )
 
     doc2 = TextPairDocumentWithLabeledSpansAndBinaryCorefRelations(
-        id="0", text="Bob loves his cat.", text_pair="She sleeps a lot."
+        id="1",
+        text="Bob loves his cat.",
+        text_pair="She sleeps a lot.",
+        metadata={"original_doc_id": "doc1"},
     )
     doc2.labeled_spans.append(LabeledSpan(start=0, end=3, label="PERSON"))
     doc2.labeled_spans.append(LabeledSpan(start=10, end=17, label="ANIMAL"))

--- a/tests/document/processing/test_text_pair.py
+++ b/tests/document/processing/test_text_pair.py
@@ -223,7 +223,7 @@ def test_positive_documents(positive_documents):
 
 @pytest.fixture(scope="module")
 def positive_and_negative_documents(positive_documents):
-    docs = list(add_negative_coref_relations(positive_documents))
+    docs = list(add_negative_coref_relations(positive_documents, enforce_same_original_doc_id=True))
     return docs
 
 

--- a/tests/document/processing/test_text_pair.py
+++ b/tests/document/processing/test_text_pair.py
@@ -139,8 +139,8 @@ def test_construct_text_pair_coref_documents_from_partitions_via_relations(text_
     doc = all_docs["doc2[0:18]+doc2[19:36]"]
     assert doc.metadata["original_doc_id"] == "doc2"
     assert doc.metadata["original_doc_id_pair"] == "doc2"
-    assert doc.metadata["original_span"] == {"end": 18, "start": 0}
-    assert doc.metadata["original_span_pair"] == {"end": 36, "start": 19}
+    assert doc.metadata["original_doc_span"] == {"end": 18, "start": 0}
+    assert doc.metadata["original_doc_span_pair"] == {"end": 36, "start": 19}
     assert doc.text == "Bob loves his cat."
     assert doc.text_pair == "She sleeps a lot."
     assert doc.labeled_spans.resolve() == [("PERSON", "Bob"), ("ANIMAL", "his cat")]
@@ -152,8 +152,8 @@ def test_construct_text_pair_coref_documents_from_partitions_via_relations(text_
     doc = all_docs["doc1[0:20]+doc1[21:39]"]
     assert doc.metadata["original_doc_id"] == "doc1"
     assert doc.metadata["original_doc_id_pair"] == "doc1"
-    assert doc.metadata["original_span"] == {"end": 20, "start": 0}
-    assert doc.metadata["original_span_pair"] == {"end": 39, "start": 21}
+    assert doc.metadata["original_doc_span"] == {"end": 20, "start": 0}
+    assert doc.metadata["original_doc_span_pair"] == {"end": 39, "start": 21}
     assert doc.text == "Entity A works at B."
     assert doc.text_pair == "And she founded C."
     assert doc.labeled_spans.resolve() == [("PERSON", "Entity A"), ("COMPANY", "B")]
@@ -172,8 +172,8 @@ def positive_documents():
         metadata={
             "original_doc_id": "doc1",
             "original_doc_id_pair": "doc1",
-            "original_span": {"start": 0, "end": 20},
-            "original_span_pair": {"start": 25, "end": 43},
+            "original_doc_span": {"start": 0, "end": 20},
+            "original_doc_span_pair": {"start": 25, "end": 43},
         },
     )
     doc1.labeled_spans.append(LabeledSpan(start=0, end=8, label="PERSON"))
@@ -191,8 +191,8 @@ def positive_documents():
         metadata={
             "original_doc_id": "doc1",
             "original_doc_id_pair": "doc1",
-            "original_span": {"start": 0, "end": 18},
-            "original_span_pair": {"start": 20, "end": 37},
+            "original_doc_span": {"start": 0, "end": 18},
+            "original_doc_span_pair": {"start": 20, "end": 37},
         },
     )
     doc2.labeled_spans.append(LabeledSpan(start=0, end=3, label="PERSON"))
@@ -423,8 +423,8 @@ def test_construct_negative_documents_with_downsampling(positive_documents, capl
         metadata={
             "original_doc_id": "doc1",
             "original_doc_id_pair": "doc1",
-            "original_span": {"start": 0, "end": 18},
-            "original_span_pair": {"start": 20, "end": 37},
+            "original_doc_span": {"start": 0, "end": 18},
+            "original_doc_span_pair": {"start": 20, "end": 37},
         },
     )
     doc2.labeled_spans.append(LabeledSpan(start=0, end=3, label="PERSON"))

--- a/tests/document/processing/test_text_pair.py
+++ b/tests/document/processing/test_text_pair.py
@@ -223,7 +223,9 @@ def test_positive_documents(positive_documents):
 
 @pytest.fixture(scope="module")
 def positive_and_negative_documents(positive_documents):
-    docs = list(add_negative_coref_relations(positive_documents, enforce_same_original_doc_id=True))
+    docs = list(
+        add_negative_coref_relations(positive_documents, enforce_same_original_doc_id=True)
+    )
     return docs
 
 

--- a/tests/document/processing/test_text_pair.py
+++ b/tests/document/processing/test_text_pair.py
@@ -169,7 +169,12 @@ def positive_documents():
         id="0",
         text="Entity A works at B.",
         text_pair="And she founded C.",
-        metadata={"original_doc_id": "doc1", "original_doc_id_pair": "doc1"},
+        metadata={
+            "original_doc_id": "doc1",
+            "original_doc_id_pair": "doc1",
+            "span": {"start": 0, "end": 20},
+            "span_pair": {"start": 25, "end": 43},
+        },
     )
     doc1.labeled_spans.append(LabeledSpan(start=0, end=8, label="PERSON"))
     doc1.labeled_spans.append(LabeledSpan(start=18, end=19, label="COMPANY"))
@@ -183,7 +188,12 @@ def positive_documents():
         id="1",
         text="Bob loves his cat.",
         text_pair="She sleeps a lot.",
-        metadata={"original_doc_id": "doc1", "original_doc_id_pair": "doc1"},
+        metadata={
+            "original_doc_id": "doc1",
+            "original_doc_id_pair": "doc1",
+            "span": {"start": 0, "end": 18},
+            "span_pair": {"start": 20, "end": 37},
+        },
     )
     doc2.labeled_spans.append(LabeledSpan(start=0, end=3, label="PERSON"))
     doc2.labeled_spans.append(LabeledSpan(start=10, end=17, label="ANIMAL"))
@@ -405,7 +415,15 @@ def test_construct_negative_documents_with_downsampling(positive_documents, capl
 
     # no positives
     doc2 = TextPairDocumentWithLabeledSpansAndBinaryCorefRelations(
-        id="0", text="Bob loves his cat.", text_pair="She sleeps a lot."
+        id="0",
+        text="Bob loves his cat.",
+        text_pair="She sleeps a lot.",
+        metadata={
+            "original_doc_id": "doc1",
+            "original_doc_id_pair": "doc1",
+            "span": {"start": 0, "end": 18},
+            "span_pair": {"start": 20, "end": 37},
+        },
     )
     doc2.labeled_spans.append(LabeledSpan(start=0, end=3, label="PERSON"))
     doc2.labeled_spans.append(LabeledSpan(start=10, end=17, label="ANIMAL"))

--- a/tests/document/processing/test_text_pair.py
+++ b/tests/document/processing/test_text_pair.py
@@ -139,8 +139,8 @@ def test_construct_text_pair_coref_documents_from_partitions_via_relations(text_
     doc = all_docs["doc2[0:18]+doc2[19:36]"]
     assert doc.metadata["original_doc_id"] == "doc2"
     assert doc.metadata["original_doc_id_pair"] == "doc2"
-    assert doc.metadata["span"] == {"end": 18, "start": 0}
-    assert doc.metadata["span_pair"] == {"end": 36, "start": 19}
+    assert doc.metadata["original_span"] == {"end": 18, "start": 0}
+    assert doc.metadata["original_span_pair"] == {"end": 36, "start": 19}
     assert doc.text == "Bob loves his cat."
     assert doc.text_pair == "She sleeps a lot."
     assert doc.labeled_spans.resolve() == [("PERSON", "Bob"), ("ANIMAL", "his cat")]
@@ -152,8 +152,8 @@ def test_construct_text_pair_coref_documents_from_partitions_via_relations(text_
     doc = all_docs["doc1[0:20]+doc1[21:39]"]
     assert doc.metadata["original_doc_id"] == "doc1"
     assert doc.metadata["original_doc_id_pair"] == "doc1"
-    assert doc.metadata["span"] == {"end": 20, "start": 0}
-    assert doc.metadata["span_pair"] == {"end": 39, "start": 21}
+    assert doc.metadata["original_span"] == {"end": 20, "start": 0}
+    assert doc.metadata["original_span_pair"] == {"end": 39, "start": 21}
     assert doc.text == "Entity A works at B."
     assert doc.text_pair == "And she founded C."
     assert doc.labeled_spans.resolve() == [("PERSON", "Entity A"), ("COMPANY", "B")]
@@ -172,8 +172,8 @@ def positive_documents():
         metadata={
             "original_doc_id": "doc1",
             "original_doc_id_pair": "doc1",
-            "span": {"start": 0, "end": 20},
-            "span_pair": {"start": 25, "end": 43},
+            "original_span": {"start": 0, "end": 20},
+            "original_span_pair": {"start": 25, "end": 43},
         },
     )
     doc1.labeled_spans.append(LabeledSpan(start=0, end=8, label="PERSON"))
@@ -191,8 +191,8 @@ def positive_documents():
         metadata={
             "original_doc_id": "doc1",
             "original_doc_id_pair": "doc1",
-            "span": {"start": 0, "end": 18},
-            "span_pair": {"start": 20, "end": 37},
+            "original_span": {"start": 0, "end": 18},
+            "original_span_pair": {"start": 20, "end": 37},
         },
     )
     doc2.labeled_spans.append(LabeledSpan(start=0, end=3, label="PERSON"))
@@ -423,8 +423,8 @@ def test_construct_negative_documents_with_downsampling(positive_documents, capl
         metadata={
             "original_doc_id": "doc1",
             "original_doc_id_pair": "doc1",
-            "span": {"start": 0, "end": 18},
-            "span_pair": {"start": 20, "end": 37},
+            "original_span": {"start": 0, "end": 18},
+            "original_span_pair": {"start": 20, "end": 37},
         },
     )
     doc2.labeled_spans.append(LabeledSpan(start=0, end=3, label="PERSON"))

--- a/tests/document/processing/test_text_pair.py
+++ b/tests/document/processing/test_text_pair.py
@@ -138,6 +138,7 @@ def test_construct_text_pair_coref_documents_from_partitions_via_relations(text_
 
     doc = all_docs["doc2[0:18]+doc2[19:36]"]
     assert doc.metadata["original_doc_id"] == "doc2"
+    assert doc.metadata["original_doc_id_pair"] == "doc2"
     assert doc.metadata["span"] == {"end": 18, "start": 0}
     assert doc.metadata["span_pair"] == {"end": 36, "start": 19}
     assert doc.text == "Bob loves his cat."
@@ -150,6 +151,7 @@ def test_construct_text_pair_coref_documents_from_partitions_via_relations(text_
 
     doc = all_docs["doc1[0:20]+doc1[21:39]"]
     assert doc.metadata["original_doc_id"] == "doc1"
+    assert doc.metadata["original_doc_id_pair"] == "doc1"
     assert doc.metadata["span"] == {"end": 20, "start": 0}
     assert doc.metadata["span_pair"] == {"end": 39, "start": 21}
     assert doc.text == "Entity A works at B."
@@ -167,7 +169,7 @@ def positive_documents():
         id="0",
         text="Entity A works at B.",
         text_pair="And she founded C.",
-        metadata={"original_doc_id": "doc1"},
+        metadata={"original_doc_id": "doc1", "original_doc_id_pair": "doc1"},
     )
     doc1.labeled_spans.append(LabeledSpan(start=0, end=8, label="PERSON"))
     doc1.labeled_spans.append(LabeledSpan(start=18, end=19, label="COMPANY"))
@@ -181,7 +183,7 @@ def positive_documents():
         id="1",
         text="Bob loves his cat.",
         text_pair="She sleeps a lot.",
-        metadata={"original_doc_id": "doc1"},
+        metadata={"original_doc_id": "doc1", "original_doc_id_pair": "doc1"},
     )
     doc2.labeled_spans.append(LabeledSpan(start=0, end=3, label="PERSON"))
     doc2.labeled_spans.append(LabeledSpan(start=10, end=17, label="ANIMAL"))


### PR DESCRIPTION
This changes `construct_text_pair_coref_documents_from_partitions_via_relations()` to add the following to metadata:
 - `original_doc_id`: doc id of the original document where the `text` is from
 - `original_doc_id_pair`: doc id of the original document where the `text_pair` is from
 - `original_doc_span`: a dict with `start` and `end` keys indicating where the `text` is from with respect to the original doc
 - `original_doc_span_pair`: a dict with `start` and `end` keys indicating where the `text_pair` is from with respect to the original doc

Also, this gets correctly propagated in`add_negative_coref_relations()`, when available.

Finally, this adds the parameter `enforce_same_original_doc_id` to `add_negative_coref_relations()`. If enabled, only negatives where both `text` and `text_pair` are from the same original document, get created.