### PR TITLE
add parameter `enforce_different_original_doc_id` to `add_negative_coref_relations()`

### DIFF
--- a/src/pie_modules/document/processing/text_pair.py
+++ b/src/pie_modules/document/processing/text_pair.py
@@ -199,6 +199,7 @@ def add_negative_coref_relations(
     downsampling_factor: Optional[float] = None,
     random_seed: Optional[int] = None,
     enforce_same_original_doc_id: bool = False,
+    enforce_different_original_doc_id: bool = False,
 ) -> Iterable[TextPairDocumentWithLabeledSpansAndBinaryCorefRelations]:
     positive_tuples = defaultdict(set)
     text2spans = defaultdict(set)
@@ -232,6 +233,13 @@ def add_negative_coref_relations(
                         "enforce_same_original_doc_id is set, but original_doc_id(_pair) is None"
                     )
                 if original_doc_id != original_doc_id_pair:
+                    continue
+            if enforce_different_original_doc_id:
+                if original_doc_id is None or original_doc_id_pair is None:
+                    raise ValueError(
+                        "enforce_different_original_doc_id is set, but original_doc_id(_pair) is None"
+                    )
+                if original_doc_id == original_doc_id_pair:
                     continue
             current_positives = positive_tuples.get((text, text_pair), set())
             new_doc = TextPairDocumentWithLabeledSpansAndBinaryCorefRelations(

--- a/tests/document/processing/test_text_pair.py
+++ b/tests/document/processing/test_text_pair.py
@@ -439,6 +439,16 @@ def test_construct_negative_documents_with_downsampling(positive_documents, capl
     )
 
 
+def test_construct_negative_documents_with_enforce_different_original_doc_id(
+    positive_documents, caplog
+):
+    docs = list(
+        add_negative_coref_relations(positive_documents, enforce_different_original_doc_id=True)
+    )
+    # no result docs, because there is only one "original" doc
+    assert len(docs) == 0
+
+
 def test_construct_text_document_from_text_pair_coref_document(positive_and_negative_documents):
     glue_text = "<s><s>"
     docs = [


### PR DESCRIPTION
Note: If enabled, this will also remove all positives where the original doc ids are the same!