### PR TITLE
move non-core dependencies to dev group

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3439,4 +3439,4 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "3d547221803d90a0748f39366973791fe56d6d2ff61589da70ba56885d0aab81"
+content-hash = "cef09df82528699c69ae2d1e6bc58671e8201a43aae219c604ecd208e4761ee6"

--- a/poetry.lock
+++ b/poetry.lock
@@ -3439,4 +3439,4 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "d66ae3c6fee7d4089145f070a2c6a8cabb2223bc8102be93aa2f20cbf72ea674"
+content-hash = "3d547221803d90a0748f39366973791fe56d6d2ff61589da70ba56885d0aab81"

--- a/poetry.lock
+++ b/poetry.lock
@@ -3439,4 +3439,4 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "cef09df82528699c69ae2d1e6bc58671e8201a43aae219c604ecd208e4761ee6"
+content-hash = "9edc2e1c448159e3f55c1d7fb1c6fa1d2baa9a11b2ef6e8aa80d5f551789ecac"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,6 @@ python = "^3.9"
 pytorch-ie = ">=0.31.2,<0.32.0"
 pytorch-lightning = "^2.1.0"
 torchmetrics = "^1"
-pytorch-crf = ">=0.7.2"
 # for SpansViaRelationMerger
 networkx = "^3.0.0"
 # >=4.35 because of BartModelWithDecoderPositionIds, <4.37 because of generation config
@@ -36,6 +35,7 @@ transformers = ">=4.35.0,<4.37.0"
 
 [tool.poetry.group.dev.dependencies]
 torch = {version = "^2.1.0+cpu", source = "pytorch"}
+pytorch-crf = ">=0.7.2"
 pytest = "^7.4.2"
 pytest-cov = "^4.1.0"
 pre-commit = "^3.4.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,23 +27,24 @@ python = "^3.9"
 pytorch-ie = ">=0.31.2,<0.32.0"
 pytorch-lightning = "^2.1.0"
 torchmetrics = "^1"
-# for SpansViaRelationMerger
-networkx = "^3.0.0"
 # >=4.35 because of BartModelWithDecoderPositionIds, <4.37 because of generation config
 # created from model config in BartAsPointerNetwork
 transformers = ">=4.35.0,<4.37.0"
 
 [tool.poetry.group.dev.dependencies]
 torch = {version = "^2.1.0+cpu", source = "pytorch"}
-pytorch-crf = ">=0.7.2"
 pytest = "^7.4.2"
 pytest-cov = "^4.1.0"
 pre-commit = "^3.4.0"
 tabulate = "^0.9"
-# for rouge metric and for NltkSentenceSplitter
+# for TokenClassificationModelWithSeq2SeqEncoderAndCrf
+pytorch-crf = ">=0.7.2"
+# for rouge metric (tests only) and for NltkSentenceSplitter
 nltk = "^3.8.1"
 # for NltkSentenceSplitter
 flair = "^0.13.1"
+# for SpansViaRelationMerger
+networkx = "^3.0.0"
 
 [[tool.poetry.source]]
 name = "pytorch"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,9 +33,6 @@ networkx = "^3.0.0"
 # >=4.35 because of BartModelWithDecoderPositionIds, <4.37 because of generation config
 # created from model config in BartAsPointerNetwork
 transformers = ">=4.35.0,<4.37.0"
-# for NltkSentenceSplitter
-nltk = "^3.8.1"
-flair = "^0.13.1"
 
 [tool.poetry.group.dev.dependencies]
 torch = {version = "^2.1.0+cpu", source = "pytorch"}
@@ -43,8 +40,10 @@ pytest = "^7.4.2"
 pytest-cov = "^4.1.0"
 pre-commit = "^3.4.0"
 tabulate = "^0.9"
-# for rouge metric
+# for rouge metric and for NltkSentenceSplitter
 nltk = "^3.8.1"
+# for NltkSentenceSplitter
+flair = "^0.13.1"
 
 [[tool.poetry.source]]
 name = "pytorch"

--- a/src/pie_modules/document/processing/merge_spans_via_relation.py
+++ b/src/pie_modules/document/processing/merge_spans_via_relation.py
@@ -1,7 +1,6 @@
 import logging
 from typing import Optional, Sequence, Set, Tuple, TypeVar, Union
 
-import networkx as nx
 from pytorch_ie import AnnotationLayer
 from pytorch_ie.core import Document
 
@@ -20,6 +19,8 @@ def _merge_spans_via_relation(
     link_relation_label: str,
     create_multi_spans: bool = True,
 ) -> Tuple[Union[Set[LabeledSpan], Set[LabeledMultiSpan]], Set[BinaryRelation]]:
+    import networkx as nx
+
     # convert list of relations to a graph to easily calculate connected components to merge
     g = nx.Graph()
     link_relations = []

--- a/src/pie_modules/document/processing/merge_spans_via_relation.py
+++ b/src/pie_modules/document/processing/merge_spans_via_relation.py
@@ -19,7 +19,13 @@ def _merge_spans_via_relation(
     link_relation_label: str,
     create_multi_spans: bool = True,
 ) -> Tuple[Union[Set[LabeledSpan], Set[LabeledMultiSpan]], Set[BinaryRelation]]:
-    import networkx as nx
+    try:
+        import networkx as nx
+    except ImportError:
+        raise ImportError(
+            "NetworkX must be installed to use the SpansViaRelationMerger. "
+            "You can install NetworkX with `pip install networkx`."
+        )
 
     # convert list of relations to a graph to easily calculate connected components to merge
     g = nx.Graph()

--- a/src/pie_modules/document/processing/sentence_splitter.py
+++ b/src/pie_modules/document/processing/sentence_splitter.py
@@ -33,7 +33,13 @@ class NltkSentenceSplitter:
         sentencizer_url: str = "tokenizers/punkt/PY3/english.pickle",
         inplace: bool = True,
     ):
-        import nltk
+        try:
+            import nltk
+        except ImportError:
+            raise ImportError(
+                "NLTK must be installed to use the NltkSentenceSplitter. "
+                "You can install NLTK with `pip install nltk`."
+            )
 
         self.partition_layer_name = partition_layer_name
         self.text_field_name = text_field_name
@@ -83,7 +89,13 @@ class FlairSegtokSentenceSplitter:
         text_field_name: str = "text",
         inplace: bool = True,
     ):
-        from flair.splitter import SegtokSentenceSplitter
+        try:
+            from flair.splitter import SegtokSentenceSplitter
+        except ImportError:
+            raise ImportError(
+                "Flair must be installed to use the FlairSegtokSentenceSplitter. "
+                "You can install Flair with `pip install flair`."
+            )
 
         self.partition_layer_name = partition_layer_name
         self.text_field_name = text_field_name

--- a/src/pie_modules/document/processing/sentence_splitter.py
+++ b/src/pie_modules/document/processing/sentence_splitter.py
@@ -1,11 +1,8 @@
 from __future__ import annotations
 
 import logging
-import ssl
 from typing import TypeVar
 
-import nltk
-from flair.splitter import SegtokSentenceSplitter
 from pytorch_ie.annotations import LabeledSpan
 from pytorch_ie.documents import TextDocumentWithLabeledPartitions
 
@@ -36,6 +33,8 @@ class NltkSentenceSplitter:
         sentencizer_url: str = "tokenizers/punkt/PY3/english.pickle",
         inplace: bool = True,
     ):
+        import nltk
+
         self.partition_layer_name = partition_layer_name
         self.text_field_name = text_field_name
         self.inplace = inplace
@@ -84,6 +83,8 @@ class FlairSegtokSentenceSplitter:
         text_field_name: str = "text",
         inplace: bool = True,
     ):
+        from flair.splitter import SegtokSentenceSplitter
+
         self.partition_layer_name = partition_layer_name
         self.text_field_name = text_field_name
         self.sentencizer = SegtokSentenceSplitter()

--- a/src/pie_modules/models/token_classification_with_seq2seq_encoder_and_crf.py
+++ b/src/pie_modules/models/token_classification_with_seq2seq_encoder_and_crf.py
@@ -138,7 +138,13 @@ class TokenClassificationModelWithSeq2SeqEncoderAndCrf(
         self.classifier = nn.Linear(hidden_size, num_classes)
 
         if use_crf:
-            from torchcrf import CRF
+            try:
+                from torchcrf import CRF
+            except ImportError:
+                raise ImportError(
+                    "To use CRFs, the torchcrf package must be installed. "
+                    "You can install it with `pip install pytorch-crf`."
+                )
 
             self.crf = CRF(num_tags=num_classes, batch_first=True)
         else:

--- a/src/pie_modules/models/token_classification_with_seq2seq_encoder_and_crf.py
+++ b/src/pie_modules/models/token_classification_with_seq2seq_encoder_and_crf.py
@@ -6,7 +6,6 @@ from pytorch_ie.core import PyTorchIEModel
 from pytorch_ie.models.interface import RequiresModelNameOrPath, RequiresNumClasses
 from pytorch_lightning.utilities.types import OptimizerLRScheduler
 from torch import FloatTensor, LongTensor, nn
-from torchcrf import CRF
 from transformers import (
     AutoConfig,
     AutoModel,
@@ -138,7 +137,12 @@ class TokenClassificationModelWithSeq2SeqEncoderAndCrf(
 
         self.classifier = nn.Linear(hidden_size, num_classes)
 
-        self.crf = CRF(num_tags=num_classes, batch_first=True) if use_crf else None
+        if use_crf:
+            from torchcrf import CRF
+
+            self.crf = CRF(num_tags=num_classes, batch_first=True)
+        else:
+            self.crf = None
 
     def decode(self, inputs: InputType, outputs: OutputType) -> TargetType:
         result = {}


### PR DESCRIPTION
... to reduce potential dependency conflicts when not using such optional functionality. 

In detail, we move (now lazily imported in):
- `flair` (`FlairSegtokSentenceSplitter`)
- `nltk` (`NltkSentenceSplitter`)
- `pytorch-crf`: (`TokenClassificationModelWithSeq2SeqEncoderAndCrf`)
- `networkx`: (`SpansViaRelationMerger`)