### PR TITLE
fix `token_based_document_to_text_based` / `text_based_document_to_token_based` for dependent predicted annotations 

### DIFF
--- a/src/pie_modules/document/processing/tokenization.py
+++ b/src/pie_modules/document/processing/tokenization.py
@@ -257,7 +257,9 @@ def text_based_document_to_token_based(
     )
     if added_annotations is not None:
         for layer_name, orig_ann_id2new_ann in added_annotations_from_remaining_layers.items():
-            ann_id2ann = {ann._id: ann for ann in doc[layer_name]}
+            ann_id2ann = {
+                ann._id: ann for ann in list(doc[layer_name]) + list(doc[layer_name].predictions)
+            }
             annotation_mapping = {
                 ann_id2ann[orig_ann_id]: new_ann
                 for orig_ann_id, new_ann in orig_ann_id2new_ann.items()
@@ -385,7 +387,9 @@ def token_based_document_to_text_based(
     )
     if added_annotations is not None:
         for layer_name, orig_ann_id2new_ann in added_annotations_from_remaining_layers.items():
-            ann_id2ann = {ann._id: ann for ann in doc[layer_name]}
+            ann_id2ann = {
+                ann._id: ann for ann in list(doc[layer_name]) + list(doc[layer_name].predictions)
+            }
             annotation_mapping = {
                 ann_id2ann[orig_ann_id]: new_ann
                 for orig_ann_id, new_ann in orig_ann_id2new_ann.items()


### PR DESCRIPTION
...by constructing annotation lookup table also from predictions. This fixes a regression introduced in #126.

Note: The error occurred when any of the span layers have a dependent layer (e.g. relations) which have predictions. The predictions of these dependent layers are added, but the mapping (old ids to new annotations) was not correctly converted.