### PR TITLE
fix RE with `allow_discontinuous_text`

### DIFF
--- a/src/pie_modules/taskmodules/re_text_classification_with_indices.py
+++ b/src/pie_modules/taskmodules/re_text_classification_with_indices.py
@@ -769,7 +769,14 @@ class RETextClassificationWithIndicesTaskModule(
                         for arg in args:
                             arg_center = (arg.token_span.end + arg.token_span.start) // 2
                             arg_frame_start = arg_center - max_tokens_per_argument // 2
+                            # shift the frame to the right if it is out of bounds
+                            if arg_frame_start < 0:
+                                arg_frame_start = 0
                             arg_frame_end = arg_frame_start + max_tokens_per_argument
+                            # shift the frame to the left if it is out of bounds
+                            if arg_frame_end > len(input_ids):
+                                arg_frame_end = len(input_ids)
+                                arg_frame_start = arg_frame_end - max_tokens_per_argument
                             mask[arg_frame_start:arg_frame_end] = 1
                         offsets = np.cumsum(mask != 1)
                         arg_cluster_offset_values = set()

--- a/src/pie_modules/taskmodules/re_text_classification_with_indices.py
+++ b/src/pie_modules/taskmodules/re_text_classification_with_indices.py
@@ -767,6 +767,10 @@ class RETextClassificationWithIndicesTaskModule(
 
                         mask = np.zeros_like(input_ids)
                         for arg in args:
+                            # if the input is already fully covered by one argument frame, we keep everything
+                            if len(input_ids) <= max_tokens_per_argument:
+                                mask[:] = 1
+                                break
                             arg_center = (arg.token_span.end + arg.token_span.start) // 2
                             arg_frame_start = arg_center - max_tokens_per_argument // 2
                             # shift the frame to the right if it is out of bounds
@@ -774,9 +778,16 @@ class RETextClassificationWithIndicesTaskModule(
                                 arg_frame_start = 0
                             arg_frame_end = arg_frame_start + max_tokens_per_argument
                             # shift the frame to the left if it is out of bounds
+                            # Note that this can not cause to have arg_frame_start < 0 because we already
+                            # checked that the frame is not larger than the input.
                             if arg_frame_end > len(input_ids):
                                 arg_frame_end = len(input_ids)
                                 arg_frame_start = arg_frame_end - max_tokens_per_argument
+                            # still, a sanity check
+                            if arg_frame_start < 0:
+                                raise ValueError(
+                                    f"arg_frame_start={arg_frame_start} < 0 after adjusting arg_frame_end={arg_frame_end}"
+                                )
                             mask[arg_frame_start:arg_frame_end] = 1
                         offsets = np.cumsum(mask != 1)
                         arg_cluster_offset_values = set()

--- a/tests/taskmodules/test_re_text_classification_with_indices.py
+++ b/tests/taskmodules/test_re_text_classification_with_indices.py
@@ -822,13 +822,16 @@ def test_encode_with_allow_discontinuous_text_and_binary_relations():
     )
     sep_token = taskmodule.tokenizer.sep_token
     doc = TextDocumentWithLabeledSpansAndBinaryRelations(
-        text="Loren ipsun dolor sit anet, consectetur adipisci elit, sed eiusnod tenpor incidunt ut labore et dolore nagna aliqua."
+        text="Loren ipsun dolor sit anet, consectetur adipisci elit, sed eiusnod tenpor incidunt "
+        "ut labore et dolore nagna aliqua."
         + sep_token
-        + "Ut enin ad ninin venian, quis nostrun exercitationen ullan corporis suscipit laboriosan, nisi ut aliquid ex ea connodi consequatur."
+        + "Ut enin ad ninin venian, quis nostrun exercitationen ullan corporis suscipit laboriosan, "
+        "nisi ut aliquid ex ea connodi consequatur."
         + sep_token
         + "Quis aute iure reprehenderit in voluptate velit esse cillun dolore eu fugiat nulla pariatur."
         + sep_token
-        + "Excepteur sint obcaecat cupiditat non proident, sunt in culpa qui officia deserunt nollit anin id est laborun.",
+        + "Excepteur sint obcaecat cupiditat non proident, sunt in culpa qui officia deserunt nollit "
+        "anin id est laborun.",
         id="123",
     )
 
@@ -844,11 +847,13 @@ def test_encode_with_allow_discontinuous_text_and_binary_relations():
     assert doc.labeled_spans.resolve() == [
         (
             "claim",
-            "Loren ipsun dolor sit anet, consectetur adipisci elit, sed eiusnod tenpor incidunt ut labore et dolore nagna aliqua.",
+            "Loren ipsun dolor sit anet, consectetur adipisci elit, sed eiusnod tenpor incidunt ut "
+            "labore et dolore nagna aliqua.",
         ),
         (
             "sentence",
-            "Ut enin ad ninin venian, quis nostrun exercitationen ullan corporis suscipit laboriosan, nisi ut aliquid ex ea connodi consequatur.",
+            "Ut enin ad ninin venian, quis nostrun exercitationen ullan corporis suscipit laboriosan, "
+            "nisi ut aliquid ex ea connodi consequatur.",
         ),
         (
             "sentence",
@@ -856,7 +861,8 @@ def test_encode_with_allow_discontinuous_text_and_binary_relations():
         ),
         (
             "sentence",
-            "Excepteur sint obcaecat cupiditat non proident, sunt in culpa qui officia deserunt nollit anin id est laborun.",
+            "Excepteur sint obcaecat cupiditat non proident, sunt in culpa qui officia deserunt nollit "
+            "anin id est laborun.",
         ),
     ]
 
@@ -882,17 +888,26 @@ def test_encode_with_allow_discontinuous_text_and_binary_relations():
 
     assert (
         decoded_arg_start
-        == "[CLS] [H] Loren ipsun dolor sit anet, consectetur adipisci elit, sed eiusnod tenpor incidunt ut labore et dolore nagna aliqua. [/H] [SEP] Ut enin ad ninin venian, quis [SEP] ea connodi consequatur. [SEP] [T] Quis aute iure reprehenderit in voluptate velit esse cillun dolore eu fugiat nulla pariatur. [/T] [SEP] Excepteur sint obcaecat cup [SEP]"
+        == "[CLS] [H] Loren ipsun dolor sit anet, consectetur adipisci elit, sed eiusnod tenpor "
+        "incidunt ut labore et dolore nagna aliqua. [/H] [SEP] Ut enin ad ninin venian, quis "
+        "[SEP] ea connodi consequatur. [SEP] [T] Quis aute iure reprehenderit in voluptate "
+        "velit esse cillun dolore eu fugiat nulla pariatur. [/T] [SEP] Excepteur sint obcaecat "
+        "cup [SEP]"
     )
 
     assert (
         decoded_arg_end
-        == "[CLS] [T] Loren ipsun dolor sit anet, consectetur adipisci elit, sed eiusnod tenpor incidunt ut labore et dolore nagna aliqua. [/T] [SEP] Ut enin ad ninin venian, quis [SEP] cillun dolore eu fugiat nulla pariatur. [SEP] [H] Excepteur sint obcaecat cupiditat non proident, sunt in culpa qui officia deserunt nollit anin id est laborun. [/H] [SEP]"
+        == "[CLS] [T] Loren ipsun dolor sit anet, consectetur adipisci elit, sed eiusnod tenpor incidunt "
+        "ut labore et dolore nagna aliqua. [/T] [SEP] Ut enin ad ninin venian, quis [SEP] cillun "
+        "dolore eu fugiat nulla pariatur. [SEP] [H] Excepteur sint obcaecat cupiditat non proident, "
+        "sunt in culpa qui officia deserunt nollit anin id est laborun. [/H] [SEP]"
     )
 
     assert (
         decoded_arg_consecutive
-        == "[CLS] ea connodi consequatur. [SEP] [H] Quis aute iure reprehenderit in voluptate velit esse cillun dolore eu fugiat nulla pariatur. [/H] [SEP] [T] Excepteur sint obcaecat cupiditat non proident, sunt in culpa qui officia deserunt nollit anin id est laborun. [/T] [SEP]"
+        == "[CLS] ea connodi consequatur. [SEP] [H] Quis aute iure reprehenderit in voluptate velit esse "
+        "cillun dolore eu fugiat nulla pariatur. [/H] [SEP] [T] Excepteur sint obcaecat cupiditat non "
+        "proident, sunt in culpa qui officia deserunt nollit anin id est laborun. [/T] [SEP]"
     )
 
 

--- a/tests/taskmodules/test_re_text_classification_with_indices.py
+++ b/tests/taskmodules/test_re_text_classification_with_indices.py
@@ -806,8 +806,11 @@ def test_encode_with_allow_discontinuous_text(documents):
 
 
 def test_encode_with_allow_discontinuous_text_and_binary_relations():
-    """This checks whether relation arguments at the very beginning or end of the document are encoded correctly.
-    Also, it checks whether the encoding of the consecutive spans that fit within the frame specified by max_window is correct.
+    """This checks whether relation arguments at the very beginning or end of the document are
+    encoded correctly.
+
+    Also, it checks whether the encoding of the consecutive spans that fit within the frame
+    specified by max_window is correct.
     """
     tokenizer_name_or_path = "bert-base-cased"
     taskmodule = RETextClassificationWithIndicesTaskModule(

--- a/tests/taskmodules/test_re_text_classification_with_indices.py
+++ b/tests/taskmodules/test_re_text_classification_with_indices.py
@@ -820,33 +820,33 @@ def test_encode_with_allow_discontinuous_text_and_binary_relations():
         add_argument_indices_to_input=True,
         add_global_attention_mask_to_input=True,
     )
-    sep_token = taskmodule.tokenizer.sep_token
+    texts = [
+        "Loren ipsun dolor sit anet, consectetur adipisci elit, sed eiusnod tenpor incidunt ut labore et dolore nagna aliqua.",
+        "Ut enin ad ninin venian, quis nostrun exercitationen ullan corporis suscipit laboriosan, nisi ut aliquid ex ea connodi consequatur.",
+        "Quis aute iure reprehenderit in voluptate velit esse cillun dolore eu fugiat nulla pariatur.",
+        "Excepteur sint obcaecat cupiditat non proident, sunt in culpa qui officia deserunt nollit anin id est laborun.",
+    ]
+    text_lengths = [len(text) for text in texts]
+    sep = " "
+
     doc = TextDocumentWithLabeledSpansAndBinaryRelations(
-        text="Loren ipsun dolor sit anet, consectetur adipisci elit, sed eiusnod tenpor incidunt "
-        "ut labore et dolore nagna aliqua."
-        + sep_token
-        + "Ut enin ad ninin venian, quis nostrun exercitationen ullan corporis suscipit laboriosan, "
-        "nisi ut aliquid ex ea connodi consequatur."
-        + sep_token
-        + "Quis aute iure reprehenderit in voluptate velit esse cillun dolore eu fugiat nulla pariatur."
-        + sep_token
-        + "Excepteur sint obcaecat cupiditat non proident, sunt in culpa qui officia deserunt nollit "
-        "anin id est laborun.",
+        text=sep.join(texts),
         id="123",
     )
 
-    labeled_spans = [
-        LabeledSpan(start=0, end=116, label="claim", score=1.0),
-        LabeledSpan(start=121, end=252, label="sentence", score=1.0),
-        LabeledSpan(start=257, end=349, label="sentence", score=1.0),
-        LabeledSpan(start=354, end=464, label="sentence", score=1.0),
-    ]
+    labeled_spans = []
+    offset = 0
+    for i, text in enumerate(texts):
+        labeled_spans.append(
+            LabeledSpan(start=0 + offset, end=text_lengths[i] + offset, label="sentence")
+        )
+        offset += text_lengths[i] + len(sep)
 
     for span in labeled_spans:
         doc.labeled_spans.append(span)
     assert doc.labeled_spans.resolve() == [
         (
-            "claim",
+            "sentence",
             "Loren ipsun dolor sit anet, consectetur adipisci elit, sed eiusnod tenpor incidunt ut "
             "labore et dolore nagna aliqua.",
         ),
@@ -888,26 +888,17 @@ def test_encode_with_allow_discontinuous_text_and_binary_relations():
 
     assert (
         decoded_arg_start
-        == "[CLS] [H] Loren ipsun dolor sit anet, consectetur adipisci elit, sed eiusnod tenpor "
-        "incidunt ut labore et dolore nagna aliqua. [/H] [SEP] Ut enin ad ninin venian, quis "
-        "[SEP] ea connodi consequatur. [SEP] [T] Quis aute iure reprehenderit in voluptate "
-        "velit esse cillun dolore eu fugiat nulla pariatur. [/T] [SEP] Excepteur sint obcaecat "
-        "cup [SEP]"
+        == "[CLS] [H] Loren ipsun dolor sit anet, consectetur adipisci elit, sed eiusnod tenpor incidunt ut labore et dolore nagna aliqua. [/H] Ut enin ad ninin venian, quis no [SEP] ex ea connodi consequatur. [T] Quis aute iure reprehenderit in voluptate velit esse cillun dolore eu fugiat nulla pariatur. [/T] Excepteur sint obcaecat cupid [SEP]"
     )
 
     assert (
         decoded_arg_end
-        == "[CLS] [T] Loren ipsun dolor sit anet, consectetur adipisci elit, sed eiusnod tenpor incidunt "
-        "ut labore et dolore nagna aliqua. [/T] [SEP] Ut enin ad ninin venian, quis [SEP] cillun "
-        "dolore eu fugiat nulla pariatur. [SEP] [H] Excepteur sint obcaecat cupiditat non proident, "
-        "sunt in culpa qui officia deserunt nollit anin id est laborun. [/H] [SEP]"
+        == "[CLS] [T] Loren ipsun dolor sit anet, consectetur adipisci elit, sed eiusnod tenpor incidunt ut labore et dolore nagna aliqua. [/T] Ut enin ad ninin venian, quis no [SEP]se cillun dolore eu fugiat nulla pariatur. [H] Excepteur sint obcaecat cupiditat non proident, sunt in culpa qui officia deserunt nollit anin id est laborun. [/H] [SEP]"
     )
 
     assert (
         decoded_arg_consecutive
-        == "[CLS] ea connodi consequatur. [SEP] [H] Quis aute iure reprehenderit in voluptate velit esse "
-        "cillun dolore eu fugiat nulla pariatur. [/H] [SEP] [T] Excepteur sint obcaecat cupiditat non "
-        "proident, sunt in culpa qui officia deserunt nollit anin id est laborun. [/T] [SEP]"
+        == "[CLS] ex ea connodi consequatur. [H] Quis aute iure reprehenderit in voluptate velit esse cillun dolore eu fugiat nulla pariatur. [/H] [T] Excepteur sint obcaecat cupiditat non proident, sunt in culpa qui officia deserunt nollit anin id est laborun. [/T] [SEP]"
     )
 
 

--- a/tests/taskmodules/test_re_text_classification_with_indices.py
+++ b/tests/taskmodules/test_re_text_classification_with_indices.py
@@ -809,8 +809,7 @@ def test_encode_with_allow_discontinuous_text_and_binary_relations():
     """This checks whether relation arguments at the very beginning or end of the document are encoded correctly.
     Also, it checks whether the encoding of the consecutive spans that fit within the frame specified by max_window is correct.
     """
-    tokenizer_name_or_path = "allenai/longformer-base-4096"
-    # tokenizer_name_or_path = "bert-base-cased"
+    tokenizer_name_or_path = "bert-base-cased"
     taskmodule = RETextClassificationWithIndicesTaskModule(
         tokenizer_name_or_path=tokenizer_name_or_path,
         max_window=128,
@@ -832,9 +831,9 @@ def test_encode_with_allow_discontinuous_text_and_binary_relations():
 
     labeled_spans = [
         LabeledSpan(start=0, end=116, label="claim", score=1.0),
-        LabeledSpan(start=120, end=251, label="sentence", score=1.0),
-        LabeledSpan(start=255, end=347, label="sentence", score=1.0),
-        LabeledSpan(start=351, end=461, label="sentence", score=1.0),
+        LabeledSpan(start=121, end=252, label="sentence", score=1.0),
+        LabeledSpan(start=257, end=349, label="sentence", score=1.0),
+        LabeledSpan(start=354, end=464, label="sentence", score=1.0),
     ]
 
     for span in labeled_spans:
@@ -880,17 +879,17 @@ def test_encode_with_allow_discontinuous_text_and_binary_relations():
 
     assert (
         decoded_arg_start
-        == "<s>[H]Loren ipsun dolor sit anet, consectetur adipisci elit, sed eiusnod tenpor incidunt ut labore et dolore nagna aliqua.[/H]</s>Ut enin ad ninin venian, quis nostrun exerc</s></s> ut aliquid ex ea connodi consequatur.</s>[T]Quis aute iure reprehenderit in voluptate velit esse cillun dolore eu fugiat nulla pariatur.[/T]</s>Excepteur sint obcaecat cupidit</s>"
+        == "[CLS] [H] Loren ipsun dolor sit anet, consectetur adipisci elit, sed eiusnod tenpor incidunt ut labore et dolore nagna aliqua. [/H] [SEP] Ut enin ad ninin venian, quis [SEP] ea connodi consequatur. [SEP] [T] Quis aute iure reprehenderit in voluptate velit esse cillun dolore eu fugiat nulla pariatur. [/T] [SEP] Excepteur sint obcaecat cup [SEP]"
     )
 
     assert (
         decoded_arg_end
-        == "<s>[T]Loren ipsun dolor sit anet, consectetur adipisci elit, sed eiusnod tenpor incidunt ut labore et dolore nagna aliqua.[/T]</s>Ut enin ad ninin venian, quis nostrun exerc</s></s>ate velit esse cillun dolore eu fugiat nulla pariatur.</s>[H]Excepteur sint obcaecat cupiditat non proident, sunt in culpa qui officia deserunt nollit anin id est laborun.[/H]</s>"
+        == "[CLS] [T] Loren ipsun dolor sit anet, consectetur adipisci elit, sed eiusnod tenpor incidunt ut labore et dolore nagna aliqua. [/T] [SEP] Ut enin ad ninin venian, quis [SEP] cillun dolore eu fugiat nulla pariatur. [SEP] [H] Excepteur sint obcaecat cupiditat non proident, sunt in culpa qui officia deserunt nollit anin id est laborun. [/H] [SEP]"
     )
 
     assert (
         decoded_arg_consecutive
-        == "<s> ut aliquid ex ea connodi consequatur.</s>[H]Quis aute iure reprehenderit in voluptate velit esse cillun dolore eu fugiat nulla pariatur.[/H]</s>[T]Excepteur sint obcaecat cupiditat non proident, sunt in culpa qui officia deserunt nollit anin id est laborun.[/T]</s>"
+        == "[CLS] ea connodi consequatur. [SEP] [H] Quis aute iure reprehenderit in voluptate velit esse cillun dolore eu fugiat nulla pariatur. [/H] [SEP] [T] Excepteur sint obcaecat cupiditat non proident, sunt in culpa qui officia deserunt nollit anin id est laborun. [/T] [SEP]"
     )
 
 


### PR DESCRIPTION
When setting `allow_discontinuous_text=True`, we create a per-argument mask of size `(max_length / num_arguments)` (minus number of special tokens) for the tokens to put into the model. However, it may happen that the start of this is below zero (if the argument is at the beginning of the input) or that the end exceeds the inputs (if the argument is at the very end). This caused issues for the former case because negative indices will be counted from the end of the potential mask. With this PR, this is fixed by shifting the mask to the positive range (to the right) if its default start is below zero or shifted fully into it to the left if it exceeds the end boundary.