### PR TITLE
add test for fix RE with allow_discontinuous_text

### DIFF
--- a/src/pie_modules/taskmodules/re_text_classification_with_indices.py
+++ b/src/pie_modules/taskmodules/re_text_classification_with_indices.py
@@ -769,7 +769,14 @@ class RETextClassificationWithIndicesTaskModule(
                         for arg in args:
                             arg_center = (arg.token_span.end + arg.token_span.start) // 2
                             arg_frame_start = arg_center - max_tokens_per_argument // 2
+                            # shift the frame to the right if it is out of bounds
+                            if arg_frame_start < 0:
+                                arg_frame_start = 0
                             arg_frame_end = arg_frame_start + max_tokens_per_argument
+                            # shift the frame to the left if it is out of bounds
+                            if arg_frame_end > len(input_ids):
+                                arg_frame_end = len(input_ids)
+                                arg_frame_start = arg_frame_end - max_tokens_per_argument
                             mask[arg_frame_start:arg_frame_end] = 1
                         offsets = np.cumsum(mask != 1)
                         arg_cluster_offset_values = set()

--- a/src/pie_modules/taskmodules/re_text_classification_with_indices.py
+++ b/src/pie_modules/taskmodules/re_text_classification_with_indices.py
@@ -767,6 +767,10 @@ class RETextClassificationWithIndicesTaskModule(
 
                         mask = np.zeros_like(input_ids)
                         for arg in args:
+                            # if the input is already fully covered by one argument frame, we keep everything
+                            if len(input_ids) <= max_tokens_per_argument:
+                                mask[:] = 1
+                                break
                             arg_center = (arg.token_span.end + arg.token_span.start) // 2
                             arg_frame_start = arg_center - max_tokens_per_argument // 2
                             # shift the frame to the right if it is out of bounds
@@ -774,9 +778,16 @@ class RETextClassificationWithIndicesTaskModule(
                                 arg_frame_start = 0
                             arg_frame_end = arg_frame_start + max_tokens_per_argument
                             # shift the frame to the left if it is out of bounds
+                            # Note that this can not cause to have arg_frame_start < 0 because we already
+                            # checked that the frame is not larger than the input.
                             if arg_frame_end > len(input_ids):
                                 arg_frame_end = len(input_ids)
                                 arg_frame_start = arg_frame_end - max_tokens_per_argument
+                            # still, a sanity check
+                            if arg_frame_start < 0:
+                                raise ValueError(
+                                    f"arg_frame_start={arg_frame_start} < 0 after adjusting arg_frame_end={arg_frame_end}"
+                                )
                             mask[arg_frame_start:arg_frame_end] = 1
                         offsets = np.cumsum(mask != 1)
                         arg_cluster_offset_values = set()


### PR DESCRIPTION
This adds the test for the problem fixed in https://github.com/ArneBinder/pie-modules/pull/138. The problem was related to the wrong indices for the argument spans that appear at the very beginning or at the very end of the input.

E.g. before the fix we had the following encoding for the input with an argument at the beginning (see the check [here](https://github.com/tanikina/pie-modules/blob/235253400b6ceb81fb7e6859d796cf4c66314ef2/tests/taskmodules/test_re_text_classification_with_indices.py#L858)):
>\<s\> ut aliquid ex ea connodi consequatur.\</s\>Quis a[T]ute iure reprehenderit in voluptate velit esse cillun dolore eu fugiat nulla par[/H]iatur.\</s\>Excepteur[/T] sint obcaecat cupid[H]it\</s\>

And the correct encoding should look like this:
>\<s\>[H]Loren ipsun dolor sit anet, consectetur adipisci elit, sed eiusnod tenpor incidunt ut labore et dolore nagna aliqua.[/H]\</s\>Ut enin ad ninin venian, quis nostrun exerc\</s\>\</s\> ut aliquid ex ea connodi consequatur.\</s\>[T]Quis aute iure reprehenderit in voluptate velit esse cillun dolore eu fugiat nulla pariatur.[/T]\</s\>Excepteur sint obcaecat cupidit\</s\>

I also added a test that checks the encoding for two consecutive spans that fit within the max_window size and it looks mostly fine, although I am not 100% sure whether an extra space at the beginning: `<s> ut` should be there (see the corresponding [check](https://github.com/tanikina/pie-modules/blob/235253400b6ceb81fb7e6859d796cf4c66314ef2/tests/taskmodules/test_re_text_classification_with_indices.py#L868)). I was expecting the span to start with `<s>ut`.

The right side of the assertion is based on the output after the fix in https://github.com/ArneBinder/pie-modules/pull/138 and it makes sense for the given examples.