### PR TITLE
`PointerNetworkTaskModuleForEnd2EndRE`: skip duplicated / conflicting relations druing encoding

### DIFF
--- a/src/pie_modules/taskmodules/pointer_network_for_end2end_re.py
+++ b/src/pie_modules/taskmodules/pointer_network_for_end2end_re.py
@@ -454,11 +454,20 @@ class PointerNetworkTaskModuleForEnd2EndRE(
 
         # encode relations
         all_relation_arguments = set()
+        relation_arguments2label: Dict[Tuple[Annotation, ...], str] = dict()
         relation_encodings = dict()
         for rel in layers[self.relation_layer_name]:
             if not isinstance(rel, BinaryRelation):
                 raise Exception(f"expected BinaryRelation, but got: {rel}")
             if rel.label in self.labels_per_layer[self.relation_layer_name]:
+                if (rel.head, rel.tail) in relation_arguments2label:
+                    previous_label = relation_arguments2label[(rel.head, rel.tail)]
+                    if previous_label != rel.label:
+                        logger.warning(
+                            f"relation {rel.head} -> {rel.tail} already exists, but has another label: "
+                            f"{previous_label} (previous label: {rel.label}). Skipping."
+                        )
+                    continue
                 encoded_relation = self.relation_encoder_decoder.encode(
                     annotation=rel, metadata=metadata
                 )
@@ -466,6 +475,7 @@ class PointerNetworkTaskModuleForEnd2EndRE(
                     raise Exception(f"failed to encode relation: {rel}")
                 relation_encodings[rel] = encoded_relation
                 all_relation_arguments.update([rel.head, rel.tail])
+                relation_arguments2label[(rel.head, rel.tail)] = rel.label
 
         # encode spans that are not arguments of any relation
         no_relation_spans = [

--- a/src/pie_modules/taskmodules/pointer_network_for_end2end_re.py
+++ b/src/pie_modules/taskmodules/pointer_network_for_end2end_re.py
@@ -463,9 +463,9 @@ class PointerNetworkTaskModuleForEnd2EndRE(
                 if (rel.head, rel.tail) in relation_arguments2label:
                     previous_label = relation_arguments2label[(rel.head, rel.tail)]
                     if previous_label != rel.label:
-                        logger.warning(
+                        raise ValueError(
                             f"relation {rel.head} -> {rel.tail} already exists, but has another label: "
-                            f"{previous_label} (previous label: {rel.label}). Skipping."
+                            f"{previous_label} (current label: {rel.label})."
                         )
                     continue
                 encoded_relation = self.relation_encoder_decoder.encode(

--- a/tests/taskmodules/test_pointer_network_for_end2end_re.py
+++ b/tests/taskmodules/test_pointer_network_for_end2end_re.py
@@ -351,21 +351,7 @@ def test_task_encoding_with_deduplicated_relations(caplog):
     caplog.clear()
     with caplog.at_level(logging.WARNING):
         task_encodings = taskmodule.encode(doc, encode_target=True)
-
-    assert caplog.messages == [
-        (
-            "encoding errors: {'correct': 2}, skipped annotations:\n"
-            "{\n"
-            '  "relations": [\n'
-            '    "BinaryRelation('
-            "head=LabeledSpan(start=4, end=6, label='content', score=1.0), "
-            "tail=LabeledSpan(start=7, end=8, label='topic', score=1.0), "
-            "label='is_about', score=0.9"
-            ')"\n'
-            "  ]\n"
-            "}"
-        )
-    ]
+    messages = list(caplog.messages)
 
     assert len(task_encodings) == 1
     decoded_annotations, statistics = taskmodule.decode_annotations(task_encodings[0].targets)
@@ -384,6 +370,21 @@ def test_task_encoding_with_deduplicated_relations(caplog):
             )
         ],
     }
+
+    assert messages == [
+        (
+            "encoding errors: {'correct': 2}, skipped annotations:\n"
+            "{\n"
+            '  "relations": [\n'
+            '    "BinaryRelation('
+            "head=LabeledSpan(start=4, end=6, label='content', score=1.0), "
+            "tail=LabeledSpan(start=7, end=8, label='topic', score=1.0), "
+            "label='is_about', score=0.9"
+            ')"\n'
+            "  ]\n"
+            "}"
+        )
+    ]
 
 
 def test_task_encoding_with_conflicting_relations(caplog):
@@ -419,10 +420,7 @@ def test_task_encoding_with_conflicting_relations(caplog):
     caplog.clear()
     with caplog.at_level(logging.WARNING):
         task_encodings = taskmodule.encode(doc, encode_target=True)
-    assert caplog.messages == [
-        "relation ('Ġdummy', 'Ġtext') -> ('Ġnothing',) already exists, but has another label: is_about (previous label: wrong_relation). Skipping.",
-        "encoding errors: {'correct': 2}, skipped annotations:\n{\n  \"relations\": [\n    \"BinaryRelation(head=LabeledSpan(start=4, end=6, label='content', score=1.0), tail=LabeledSpan(start=7, end=8, label='topic', score=1.0), label='wrong_relation', score=1.0)\"\n  ]\n}",
-    ]
+    messages = list(caplog.messages)
 
     assert len(task_encodings) == 1
     decoded_annotations, statistics = taskmodule.decode_annotations(task_encodings[0].targets)
@@ -441,6 +439,11 @@ def test_task_encoding_with_conflicting_relations(caplog):
             )
         ],
     }
+
+    assert messages == [
+        "relation ('Ġdummy', 'Ġtext') -> ('Ġnothing',) already exists, but has another label: is_about (previous label: wrong_relation). Skipping.",
+        "encoding errors: {'correct': 2}, skipped annotations:\n{\n  \"relations\": [\n    \"BinaryRelation(head=LabeledSpan(start=4, end=6, label='content', score=1.0), tail=LabeledSpan(start=7, end=8, label='topic', score=1.0), label='wrong_relation', score=1.0)\"\n  ]\n}",
+    ]
 
 
 @pytest.fixture()

--- a/tests/taskmodules/test_pointer_network_for_end2end_re.py
+++ b/tests/taskmodules/test_pointer_network_for_end2end_re.py
@@ -418,31 +418,16 @@ def test_task_encoding_with_conflicting_relations(caplog):
     )
     taskmodule.prepare(documents=[doc])
     caplog.clear()
-    with caplog.at_level(logging.WARNING):
+    with caplog.at_level(logging.ERROR):
         task_encodings = taskmodule.encode(doc, encode_target=True)
     messages = list(caplog.messages)
 
-    assert len(task_encodings) == 1
-    decoded_annotations, statistics = taskmodule.decode_annotations(task_encodings[0].targets)
-    assert decoded_annotations == {
-        "entities": [
-            LabeledSpan(start=4, end=6, label="content", score=1.0),
-            LabeledSpan(start=7, end=8, label="topic", score=1.0),
-            LabeledSpan(start=10, end=11, label="person", score=1.0),
-        ],
-        "relations": [
-            BinaryRelation(
-                head=LabeledSpan(start=4, end=6, label="content", score=1.0),
-                tail=LabeledSpan(start=7, end=8, label="topic", score=1.0),
-                label="is_about",
-                score=1.0,
-            )
-        ],
-    }
+    assert len(task_encodings) == 0
 
     assert messages == [
-        "relation ('Ġdummy', 'Ġtext') -> ('Ġnothing',) already exists, but has another label: is_about (previous label: wrong_relation). Skipping.",
-        "encoding errors: {'correct': 2}, skipped annotations:\n{\n  \"relations\": [\n    \"BinaryRelation(head=LabeledSpan(start=4, end=6, label='content', score=1.0), tail=LabeledSpan(start=7, end=8, label='topic', score=1.0), label='wrong_relation', score=1.0)\"\n  ]\n}",
+        "failed to encode target, it will be skipped: "
+        "relation ('Ġdummy', 'Ġtext') -> ('Ġnothing',) already exists, but has "
+        "another label: is_about (current label: wrong_relation)."
     ]
 
 


### PR DESCRIPTION
- skip relation when another relation with same arguments and **same label** was already encoded
- skip whole task encoding if another relation with same arguments and a **different label** was already encoded