### PR TITLE
`SimpleGenerativeModel`: parametrize scheduler

### DIFF
--- a/tests/models/test_simple_generative.py
+++ b/tests/models/test_simple_generative.py
@@ -389,8 +389,10 @@ def _assert_optimizer(
 
 
 def test_configure_optimizers_with_warmup(model, optimizer):
-    backup_value = model.warmup_proportion
+    warmup_proportion_backup_value = model.warmup_proportion
+    scheduler_name_backup_value = model.scheduler_name
     model.warmup_proportion = 0.1
+    model.scheduler_name = "linear"
     model.trainer = Trainer(max_epochs=10)
     optimizer_and_schedular = model.configure_optimizers()
     assert optimizer_and_schedular is not None
@@ -408,4 +410,5 @@ def test_configure_optimizers_with_warmup(model, optimizer):
     assert scheduler.optimizer is optimizers[0]
     assert scheduler.base_lrs == [13e-3]
 
-    model.warmup_proportion = backup_value
+    model.warmup_proportion = warmup_proportion_backup_value
+    model.scheduler_name = scheduler_name_backup_value


### PR DESCRIPTION
This PR adds the optional parameters `scheduler_name` and `scheduler_kwargs` to `SimpleGenerativeModel` which allows to select a training scheduler different then then the linear one. Internally, [transformers.get_scheduler](https://huggingface.co/docs/transformers/main_classes/optimizer_schedules#transformers.get_scheduler) is now used to set up the scheduler (instead of using `transformers.get_linear_schedule_with_warmup`). Note that the default behavior is kept if `scheduler_name` is not specified (i.e. if `warmup_proportion > 0.0` use linear with warmup otherwise don't use any scheduler).

See [transformers.optimization.TYPE_TO_SCHEDULER_FUNCTION](https://github.com/huggingface/transformers/blob/v4.36.2/src/transformers/optimization.py#L326-L335) for available options for `scheduler_name`.