### PR TITLE
`SimpleGenerativeModel`: override to() to call it on base model

### DIFF
--- a/src/pie_modules/models/simple_generative.py
+++ b/src/pie_modules/models/simple_generative.py
@@ -9,7 +9,7 @@ from torch import FloatTensor, LongTensor
 from torch.optim import Optimizer
 from transformers import PreTrainedModel, get_linear_schedule_with_warmup
 from transformers.modeling_outputs import Seq2SeqLMOutput
-from typing_extensions import TypeAlias
+from typing_extensions import Self, TypeAlias
 
 from pie_modules.models.common import ModelWithBoilerplate
 from pie_modules.utils import resolve_type
@@ -159,3 +159,7 @@ class SimpleGenerativeModel(
             return [optimizer], [{"scheduler": scheduler, "interval": "step"}]
         else:
             return optimizer
+
+    def to(self, *args: Any, **kwargs: Any) -> Self:
+        self.model = self.model.to(*args, **kwargs)
+        return self


### PR DESCRIPTION
Is this really necessary?

TODO:
 - [ ] check if this is not already handled by the lightning module 