### PR TITLE
tokenization: strip spans in `text_based_document_to_token_based`

### DIFF
--- a/src/pie_modules/document/processing/tokenization.py
+++ b/src/pie_modules/document/processing/tokenization.py
@@ -80,7 +80,13 @@ def char_span_to_token_span(
 ) -> Optional[Union[Span, MultiSpan]]:
     if isinstance(span, Span):
         if span.is_attached:
-            char_start, char_end = get_stripped_offsets(span.start, span.end, span.target)
+            base_text = span.targets[0]
+            if not isinstance(base_text, str):
+                raise TypeError(
+                    f"The first target of a text targeting span must be a string, but found {type(base_text)} as first "
+                    f"target type. Can not convert the span {span}."
+                )
+            char_start, char_end = get_stripped_offsets(span.start, span.end, base_text)
         else:
             char_start, char_end = span.start, span.end
         # we can not convert empty and invalid spans
@@ -93,8 +99,14 @@ def char_span_to_token_span(
         return span.copy(start=start_token_idx, end=end_token_idx_inclusive + 1)
     elif isinstance(span, MultiSpan):
         if span.is_attached:
+            base_text = span.targets[0]
+            if not isinstance(base_text, str):
+                raise TypeError(
+                    f"The first target of a text targeting span must be a string, but found {type(base_text)} as first "
+                    f"target type. Can not convert the span {span}."
+                )
             stripped_slices = [
-                get_stripped_offsets(start, end, span.target) for start, end in span.slices
+                get_stripped_offsets(start, end, base_text) for start, end in span.slices
             ]
         else:
             stripped_slices = span.slices

--- a/tests/document/processing/test_tokenization.py
+++ b/tests/document/processing/test_tokenization.py
@@ -378,11 +378,11 @@ def test_text_based_document_to_token_based_token_offset_mapping_from_metadata_i
     _test_token_document(result)
 
 
-def test_text_based_document_to_token_based_unaligned_span_strict(text_document, token_document):
+def test_text_based_document_to_token_based_space_span_strict(text_document, token_document):
     doc = TestDocument(text=text_document.text)
-    # add a span that is not aligned with the tokenization
-    doc.entities.append(LabeledSpan(start=0, end=6, label="unaligned"))
-    assert str(doc.entities[0]) == "First "
+    # add a span that is empty
+    doc.entities.append(LabeledSpan(start=5, end=6, label="unaligned"))
+    assert str(doc.entities[0]) == " "
 
     with pytest.raises(ValueError) as excinfo:
         text_based_document_to_token_based(
@@ -392,19 +392,37 @@ def test_text_based_document_to_token_based_unaligned_span_strict(text_document,
         )
     assert (
         str(excinfo.value)
-        == 'cannot find token span for character span: "First ", text="First sentence. Entity M works at N. '
+        == 'cannot find token span for character span: " ", text="First sentence. Entity M works at N. '
         'And it founded O.", token_offset_mapping=[(0, 0), (0, 5), (6, 14), (14, 15), (16, 22), (23, 24), '
         "(25, 30), (31, 33), (34, 35), (35, 36), (37, 40), (41, 43), (44, 51), (52, 53), (53, 54), (54, 54)]"
     )
 
 
-def test_text_based_document_to_token_based_unaligned_span_not_strict(
-    text_document, token_document, caplog
-):
+def test_text_based_document_to_token_based_empty_span_strict(text_document, token_document):
     doc = TestDocument(text=text_document.text)
-    # add a span that is not aligned with the tokenization
-    doc.entities.append(LabeledSpan(start=0, end=6, label="unaligned"))
-    assert str(doc.entities[0]) == "First "
+    # add a span that is empty
+    doc.entities.append(LabeledSpan(start=3, end=3, label="empty"))
+    assert str(doc.entities[0]) == ""
+
+    with pytest.raises(ValueError) as excinfo:
+        text_based_document_to_token_based(
+            doc,
+            tokens=list(token_document.tokens),
+            result_document_type=TokenizedTestDocument,
+        )
+    assert (
+        str(excinfo.value)
+        == 'cannot find token span for character span: "", text="First sentence. Entity M works at N. '
+        'And it founded O.", token_offset_mapping=[(0, 0), (0, 5), (6, 14), (14, 15), (16, 22), (23, 24), '
+        "(25, 30), (31, 33), (34, 35), (35, 36), (37, 40), (41, 43), (44, 51), (52, 53), (53, 54), (54, 54)]"
+    )
+
+
+def test_text_based_document_to_token_based_space_span(text_document, token_document, caplog):
+    doc = TestDocument(text=text_document.text)
+    # add a span that is empty
+    doc.entities.append(LabeledSpan(start=5, end=6, label="unaligned"))
+    assert str(doc.entities[0]) == " "
 
     with caplog.at_level("WARNING"):
         tokenized_doc = text_based_document_to_token_based(
@@ -416,7 +434,7 @@ def test_text_based_document_to_token_based_unaligned_span_not_strict(
     assert len(caplog.records) == 1
     assert (
         caplog.records[0].message
-        == 'cannot find token span for character span "First ", skip it (disable this warning with verbose=False)'
+        == 'cannot find token span for character span " ", skip it (disable this warning with verbose=False)'
     )
 
     # check (de-)serialization
@@ -425,6 +443,102 @@ def test_text_based_document_to_token_based_unaligned_span_not_strict(
     assert len(doc.entities) == 1
     # the unaligned span is not included in the tokenized document
     assert len(tokenized_doc.entities) == 0
+
+
+def test_text_based_document_to_token_based_trim_span(text_document, token_document):
+    doc = TestDocument(text=text_document.text)
+    # add a span that is not aligned with the tokenization
+    doc.entities.append(LabeledSpan(start=5, end=16, label="unaligned"))
+    assert str(doc.entities[0]) == " sentence. "
+
+    result_doc = text_based_document_to_token_based(
+        doc,
+        tokens=list(token_document.tokens),
+        result_document_type=TokenizedTestDocument,
+    )
+    assert result_doc.entities.resolve() == [("unaligned", ("sentence", "."))]
+
+
+def test_text_based_document_to_token_based_empty_multi_span_strict(
+    token_document_with_multi_spans, text_document_with_multi_spans
+):
+    doc = TestDocumentWithMultiSpans(text=text_document_with_multi_spans.text)
+    # add a multi span that is not aligned with the tokenization
+    doc.entities.append(LabeledMultiSpan(slices=(), label="empty"))
+    assert doc.entities.resolve() == [("empty", ())]
+
+    with pytest.raises(ValueError) as excinfo:
+        text_based_document_to_token_based(
+            doc,
+            tokens=list(token_document_with_multi_spans.tokens),
+            result_document_type=TokenizedTestDocumentWithMultiSpans,
+        )
+    assert (
+        str(excinfo.value)
+        == 'cannot find token span for character span: "()", text="First sentence. Entity M works at N. '
+        'And it founded O.", token_offset_mapping=[(0, 0), (0, 5), (6, 14), (14, 15), (16, 22), (23, 24), '
+        "(25, 30), (31, 33), (34, 35), (35, 36), (37, 40), (41, 43), (44, 51), (52, 53), (53, 54), (54, 54)]"
+    )
+
+
+def test_text_based_document_to_token_based_space_multi_span_slice_strict(
+    token_document_with_multi_spans, text_document_with_multi_spans
+):
+    doc = TestDocumentWithMultiSpans(text=text_document_with_multi_spans.text)
+    # add a multi span that is not aligned with the tokenization
+    doc.entities.append(LabeledMultiSpan(slices=((5, 6),), label="unaligned"))
+    assert doc.entities.resolve() == [("unaligned", (" ",))]
+
+    with pytest.raises(ValueError) as excinfo:
+        text_based_document_to_token_based(
+            doc,
+            tokens=list(token_document_with_multi_spans.tokens),
+            result_document_type=TokenizedTestDocumentWithMultiSpans,
+        )
+    assert (
+        str(excinfo.value)
+        == 'cannot find token span for character span: "(\' \',)", text="First sentence. Entity M works at N. '
+        'And it founded O.", token_offset_mapping=[(0, 0), (0, 5), (6, 14), (14, 15), (16, 22), (23, 24), '
+        "(25, 30), (31, 33), (34, 35), (35, 36), (37, 40), (41, 43), (44, 51), (52, 53), (53, 54), (54, 54)]"
+    )
+
+
+def test_text_based_document_to_token_based_empty_multi_span_slice_strict(
+    token_document_with_multi_spans, text_document_with_multi_spans
+):
+    doc = TestDocumentWithMultiSpans(text=text_document_with_multi_spans.text)
+    # add a multi span that is not aligned with the tokenization
+    doc.entities.append(LabeledMultiSpan(slices=((3, 3),), label="empty_slice"))
+    assert doc.entities.resolve() == [("empty_slice", ("",))]
+
+    with pytest.raises(ValueError) as excinfo:
+        text_based_document_to_token_based(
+            doc,
+            tokens=list(token_document_with_multi_spans.tokens),
+            result_document_type=TokenizedTestDocumentWithMultiSpans,
+        )
+    assert (
+        str(excinfo.value)
+        == 'cannot find token span for character span: "(\'\',)", text="First sentence. Entity M works at N. '
+        'And it founded O.", token_offset_mapping=[(0, 0), (0, 5), (6, 14), (14, 15), (16, 22), (23, 24), '
+        "(25, 30), (31, 33), (34, 35), (35, 36), (37, 40), (41, 43), (44, 51), (52, 53), (53, 54), (54, 54)]"
+    )
+
+
+def test_token_based_document_to_text_based_trim_multi_span(
+    token_document_with_multi_spans, text_document_with_multi_spans
+):
+    doc = TestDocumentWithMultiSpans(text=text_document_with_multi_spans.text)
+    # add a span that is not aligned with the tokenization
+    doc.entities.append(LabeledMultiSpan(slices=((5, 16),), label="unaligned"))
+    assert doc.entities.resolve() == [("unaligned", (" sentence. ",))]
+
+    result_doc = text_based_document_to_token_based(
+        doc,
+        tokens=list(token_document_with_multi_spans.tokens),
+        result_document_type=TokenizedTestDocumentWithMultiSpans,
+    )
+    assert result_doc.entities.resolve() == [("unaligned", (("sentence", "."),))]
 
 
 def test_text_based_document_to_token_based_wrong_annotation_type():

--- a/tests/document/processing/test_tokenization.py
+++ b/tests/document/processing/test_tokenization.py
@@ -445,7 +445,7 @@ def test_text_based_document_to_token_based_space_span(text_document, token_docu
     assert len(tokenized_doc.entities) == 0
 
 
-def test_text_based_document_to_token_based_trim_span(text_document, token_document):
+def test_text_based_document_to_token_based_strip_span(text_document, token_document):
     doc = TestDocument(text=text_document.text)
     # add a span that is not aligned with the tokenization
     doc.entities.append(LabeledSpan(start=5, end=16, label="unaligned"))
@@ -455,6 +455,7 @@ def test_text_based_document_to_token_based_trim_span(text_document, token_docum
         doc,
         tokens=list(token_document.tokens),
         result_document_type=TokenizedTestDocument,
+        strip_spans=True,
     )
     assert result_doc.entities.resolve() == [("unaligned", ("sentence", "."))]
 
@@ -525,7 +526,7 @@ def test_text_based_document_to_token_based_empty_multi_span_slice_strict(
     )
 
 
-def test_token_based_document_to_text_based_trim_multi_span(
+def test_token_based_document_to_text_based_strip_multi_span(
     token_document_with_multi_spans, text_document_with_multi_spans
 ):
     doc = TestDocumentWithMultiSpans(text=text_document_with_multi_spans.text)
@@ -537,6 +538,7 @@ def test_token_based_document_to_text_based_trim_multi_span(
         doc,
         tokens=list(token_document_with_multi_spans.tokens),
         result_document_type=TokenizedTestDocumentWithMultiSpans,
+        strip_spans=True,
     )
     assert result_doc.entities.resolve() == [("unaligned", (("sentence", "."),))]
 


### PR DESCRIPTION
This adds the parameter `strip_spans` to `text_based_document_to_token_based` and to `tokenize_document`:
```
strip_spans (bool, optional): If True, strip the whitespace from the character spans before
        converting them to token spans. Defaults to False.
```

**This is breaking** because, now:
 - empty spans (i.e. start==end) are considered as not tokenizable (in any case, not just if the (start/end) index points outside of a token)
 - multi-spans without any slices are not tokenizable
 - multi-spans are not tokenizable if *all* slices are not tokenizable (individual slices get dropped silently)