### PR TITLE
add  `argument_type_whitelist` parameter to `RETextClassificationWithIndicesTaskModule`

### DIFF
--- a/src/pie_modules/taskmodules/re_text_classification_with_indices.py
+++ b/src/pie_modules/taskmodules/re_text_classification_with_indices.py
@@ -572,9 +572,7 @@ class RETextClassificationWithIndicesTaskModule(
             if self.marker_factory.all_roles == {HEAD, TAIL}:
                 for arguments in list(arguments2relation.keys()):
                     role2arg = dict(arguments)
-                    role2label = {
-                        role: arg.label for role, arg in role2arg.items() if hasattr(arg, "label")
-                    }
+                    role2label = {role: getattr(arg, "label") for role, arg in role2arg.items()}
                     head_tail_labels = (role2label.get(HEAD), role2label.get(TAIL))
                     if head_tail_labels not in self.argument_type_whitelist:
                         rel = arguments2relation.pop(arguments)
@@ -602,7 +600,8 @@ class RETextClassificationWithIndicesTaskModule(
                         # Skip if argument_type_whitelist is defined and current candidates do not fit.
                         if (
                             self.argument_type_whitelist is not None
-                            and (head.label, tail.label) not in self.argument_type_whitelist
+                            and (getattr(head, "label"), getattr(tail, "label"))
+                            not in self.argument_type_whitelist
                         ):
                             continue
 

--- a/src/pie_modules/taskmodules/re_text_classification_with_indices.py
+++ b/src/pie_modules/taskmodules/re_text_classification_with_indices.py
@@ -337,6 +337,7 @@ class RETextClassificationWithIndicesTaskModule(
         log_first_n_examples: int = 0,
         add_argument_indices_to_input: bool = False,
         add_global_attention_mask_to_input: bool = False,
+        argument_type_whitelist: Optional[List[List[str]]] = None,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -374,6 +375,17 @@ class RETextClassificationWithIndicesTaskModule(
         self.max_argument_distance_type = max_argument_distance_type
         self.max_window = max_window
         self.allow_discontinuous_text = allow_discontinuous_text
+        self.argument_type_whitelist: Optional[List[Tuple[str, str]]] = None
+
+        if argument_type_whitelist is not None:
+            if not add_candidate_relations:
+                raise ValueError(
+                    "The parameter argument_type_whitelist should only be used with add_candidate_relations=True"
+                )
+            # hydra does not support tuples, so we got lists and need to convert them
+            self.argument_type_whitelist = [
+                (types[0], types[1]) for types in argument_type_whitelist
+            ]
 
         # overwrite None with 0 for backward compatibility
         self.log_first_n_examples = log_first_n_examples or 0
@@ -566,15 +578,23 @@ class RETextClassificationWithIndicesTaskModule(
                 # iterate over all possible argument candidates
                 for head in entities:
                     for tail in entities:
-                        if head != tail:
-                            # Create a relation candidate with the none label. Otherwise, we use the existing relation.
-                            new_relation = BinaryRelation(
-                                head=head, tail=tail, label=self.none_label, score=1.0
-                            )
-                            new_relation_args = get_relation_argument_spans_and_roles(new_relation)
-                            # we use the new relation only if there is no existing relation with the same arguments
-                            if new_relation_args not in arguments2relation:
-                                arguments2relation[new_relation_args] = new_relation
+                        if head == tail:
+                            continue
+                        # Skip if argument_type_whitelist is defined and current candidates do not fit.
+                        if (
+                            self.argument_type_whitelist is not None
+                            and (head.label, tail.label) not in self.argument_type_whitelist
+                        ):
+                            continue
+
+                        # Create a relation candidate with the none label. Otherwise, we use the existing relation.
+                        new_relation = BinaryRelation(
+                            head=head, tail=tail, label=self.none_label, score=1.0
+                        )
+                        new_relation_args = get_relation_argument_spans_and_roles(new_relation)
+                        # we use the new relation only if there is no existing relation with the same arguments
+                        if new_relation_args not in arguments2relation:
+                            arguments2relation[new_relation_args] = new_relation
             else:
                 raise NotImplementedError(
                     f"doc.id={doc_id}: the taskmodule does not yet support adding relation candidates "

--- a/tests/taskmodules/test_re_text_classification_with_indices.py
+++ b/tests/taskmodules/test_re_text_classification_with_indices.py
@@ -1178,6 +1178,63 @@ def test_encode_input_with_add_candidate_relations_with_wrong_relation_type(
     )
 
 
+def test_encode_input_with_add_candidate_relations_with_argument_type_whitelist(documents):
+    taskmodule = RETextClassificationWithIndicesTaskModule(
+        relation_annotation="relations",
+        tokenizer_name_or_path="bert-base-cased",
+        add_candidate_relations=True,
+        argument_type_whitelist=[["PER", "ORG"], ["ORG", "PER"]],
+    )
+    taskmodule.prepare(documents)
+    documents_without_relations = []
+    encodings = []
+    # just take the first five documents
+    for doc in documents[:5]:
+        doc_without_relations = doc.copy()
+        relations = list(doc_without_relations.relations)
+        doc_without_relations.relations.clear()
+        # re-add one relation to test if it is kept
+        if len(relations) > 0:
+            doc_without_relations.relations.append(relations[0])
+        documents_without_relations.append(doc_without_relations)
+        encodings.extend(taskmodule.encode(doc_without_relations))
+
+    assert len(encodings) == 10
+    relations = [encoding.metadata["candidate_annotation"] for encoding in encodings]
+    texts = [encoding.document.text for encoding in encodings]
+    relation_tuples = [(str(rel.head), rel.label, str(rel.tail)) for rel in relations]
+
+    # There are no entities in the first document, so there are no created relation candidates
+
+    # this relations were kept
+    assert texts[0] == "Entity A works at B."
+    assert relation_tuples[0] == ("Entity A", "per:employee_of", "B")
+    assert texts[6] == "First sentence. Entity G works at H. And founded I."
+    assert relation_tuples[6] == ("Entity G", "per:employee_of", "H")
+
+    # the following relations were added
+    assert texts[1] == "Entity A works at B."
+    assert relation_tuples[1] == ("B", "no_relation", "Entity A")
+    assert texts[2] == "Entity C and D."
+    assert relation_tuples[2] == ("Entity C", "no_relation", "D")
+    assert texts[3] == "Entity C and D."
+    assert relation_tuples[3] == ("D", "no_relation", "Entity C")
+    assert texts[4] == "First sentence. Entity E and F."
+    assert relation_tuples[4] == ("Entity E", "no_relation", "F")
+    assert texts[5] == "First sentence. Entity E and F."
+    assert relation_tuples[5] == ("F", "no_relation", "Entity E")
+    assert texts[7] == "First sentence. Entity G works at H. And founded I."
+    assert relation_tuples[7] == ("Entity G", "no_relation", "I")
+    assert texts[8] == "First sentence. Entity G works at H. And founded I."
+    assert relation_tuples[8] == ("H", "no_relation", "Entity G")
+    assert texts[9] == "First sentence. Entity G works at H. And founded I."
+    assert relation_tuples[9] == ("I", "no_relation", "Entity G")
+
+    # Check that not whitelisted argument pairs were not added
+    assert ("I", "no_relation", "H") not in relation_tuples
+    assert ("H", "no_relation", "I") not in relation_tuples
+
+
 def test_encode_input_with_add_reversed_relations(documents):
     tokenizer_name_or_path = "bert-base-cased"
     taskmodule = RETextClassificationWithIndicesTaskModule(

--- a/tests/taskmodules/test_re_text_classification_with_indices.py
+++ b/tests/taskmodules/test_re_text_classification_with_indices.py
@@ -1178,13 +1178,21 @@ def test_encode_input_with_add_candidate_relations_with_wrong_relation_type(
     )
 
 
-def test_encode_input_with_add_candidate_relations_with_argument_type_whitelist(documents):
+def test_add_candidate_relations_with_argument_type_whitelist(documents):
     taskmodule = RETextClassificationWithIndicesTaskModule(
         relation_annotation="relations",
         tokenizer_name_or_path="bert-base-cased",
         add_candidate_relations=True,
         argument_type_whitelist=[["PER", "ORG"], ["ORG", "PER"]],
     )
+
+    assert documents[4].entities.resolve() == [("PER", "Entity G"), ("ORG", "H"), ("ORG", "I")]
+    assert documents[4].relations.resolve() == [
+        ("per:employee_of", (("PER", "Entity G"), ("ORG", "H"))),
+        ("per:founder", (("PER", "Entity G"), ("ORG", "I"))),
+        ("org:founded_by", (("ORG", "I"), ("ORG", "H"))),
+    ]
+
     taskmodule.prepare(documents)
     encodings = taskmodule.encode(documents[4])
 
@@ -1206,7 +1214,7 @@ def test_encode_input_with_add_candidate_relations_with_argument_type_whitelist(
     assert ("no_relation", (("ORG", "H"), ("ORG", "I"))) not in relation_tuples
 
 
-def test_encode_input_with_argument_type_whitelist_without_add_candidate_relations(documents):
+def test_taskmodule_with_argument_type_whitelist_without_add_candidate_relations(documents):
     with pytest.raises(ValueError) as excinfo:
         taskmodule = RETextClassificationWithIndicesTaskModule(
             relation_annotation="relations",


### PR DESCRIPTION
Adds `argument_type_whitelist: List[List[str]]` parameter used by `_add_candidate_relations()`.

This allows adding candidates only of pre-defined argument type pairs.
E.g. when `argument_type_whitelist=[['ORG','PER']]` only relations with head.label='ORG' and tail.label='PER' will be added.

TODO:
 - [x] test in downstream setup (e.g. runs with 3 seeds at drugprot)

metric | baseline | with whitelist 
-- | -- | --
quality (micro f1) | 0.7597 (±0.0037) | 0.7737 (±0.0042)
Inference time | 83.56 | 13.5 (±0.3)
