### PR TITLE
add `handle_relations_with_same_arguments` parameter to `RETextClassificationWithIndicesTaskModule`

### DIFF
--- a/src/pie_modules/taskmodules/re_text_classification_with_indices.py
+++ b/src/pie_modules/taskmodules/re_text_classification_with_indices.py
@@ -708,7 +708,8 @@ class RETextClassificationWithIndicesTaskModule(
                             # statistics if 'collect_statistics=true' either as 'available' or as 'skipped_same_arguments'
                             logger.warning(
                                 f"doc.id={document.id}: Relation annotation `{rel.resolve()}` is duplicated. "
-                                f"We keep only one of them."
+                                f"We keep only one of them. Duplicate won't appear in statistics either as 'available' "
+                                f"or as skipped."
                             )
                             continue
                         arguments_duplicates.add(arguments)

--- a/src/pie_modules/taskmodules/re_text_classification_with_indices.py
+++ b/src/pie_modules/taskmodules/re_text_classification_with_indices.py
@@ -716,7 +716,7 @@ class RETextClassificationWithIndicesTaskModule(
                             )
                         else:
                             raise ValueError(
-                                "'handle_relations_with_same_arguments' must be 'keep_first' or 'keep_none'."
+                                f"'handle_relations_with_same_arguments' must be 'keep_first' or 'keep_none', but got `{self.handle_relations_with_same_arguments}`."
                             )
                         self.collect_relation("skipped_same_arguments", rel)
                     else:

--- a/src/pie_modules/taskmodules/re_text_classification_with_indices.py
+++ b/src/pie_modules/taskmodules/re_text_classification_with_indices.py
@@ -741,21 +741,23 @@ class RETextClassificationWithIndicesTaskModule(
                             relations[0]
                         }:  # remove all other relations
                             self.collect_relation("skipped_same_arguments", discard_rel)
-                        logger.warning(
-                            f"doc.id={document.id}: there are multiple relations with the same arguments "
-                            f"{arguments_resolved}, but different labels: {labels}. We only keep the first "
-                            f"occurring relation which has the label='{relations[0].label}'."
-                        )
+                        if not self.collect_statistics:
+                            logger.warning(
+                                f"doc.id={document.id}: there are multiple relations with the same arguments "
+                                f"{arguments_resolved}, but different labels: {labels}. We only keep the first "
+                                f"occurring relation which has the label='{relations[0].label}'."
+                            )
                     elif self.handle_relations_with_same_arguments == "keep_none":
                         # add these arguments to the blacklist to not add them as 'no-relation's back again
                         arguments_blacklist.add(arguments)
                         # remove all relations with the same arguments
                         for discard_rel in relations_set:
                             self.collect_relation("skipped_same_arguments", discard_rel)
-                        logger.warning(
-                            f"doc.id={document.id}: there are multiple relations with the same arguments "
-                            f"{arguments_resolved}, but different labels: {labels}. All relations will be removed."
-                        )
+                        if not self.collect_statistics:
+                            logger.warning(
+                                f"doc.id={document.id}: there are multiple relations with the same arguments "
+                                f"{arguments_resolved}, but different labels: {labels}. All relations will be removed."
+                            )
                     else:
                         raise ValueError(
                             f"'handle_relations_with_same_arguments' must be 'keep_first' or 'keep_none', "

--- a/src/pie_modules/taskmodules/re_text_classification_with_indices.py
+++ b/src/pie_modules/taskmodules/re_text_classification_with_indices.py
@@ -341,7 +341,6 @@ class RETextClassificationWithIndicesTaskModule(
         add_argument_indices_to_input: bool = False,
         add_global_attention_mask_to_input: bool = False,
         argument_type_whitelist: Optional[List[List[str]]] = None,
-        relations_with_same_arguments: Optional[str] = "keep_none",
         handle_relations_with_same_arguments: str = "keep_none",
         **kwargs,
     ) -> None:
@@ -381,7 +380,6 @@ class RETextClassificationWithIndicesTaskModule(
         self.max_window = max_window
         self.allow_discontinuous_text = allow_discontinuous_text
         self.handle_relations_with_same_arguments = handle_relations_with_same_arguments
-        self.relations_with_same_arguments = relations_with_same_arguments
         self.argument_type_whitelist: Optional[List[Tuple[str, str]]] = None
 
         if argument_type_whitelist is not None:

--- a/src/pie_modules/taskmodules/re_text_classification_with_indices.py
+++ b/src/pie_modules/taskmodules/re_text_classification_with_indices.py
@@ -748,8 +748,12 @@ class RETextClassificationWithIndicesTaskModule(
             self._add_candidate_relations(
                 arguments2relation=arguments2relation, entities=entities, doc_id=document.id
             )
-            # remove remaining relation duplicates. It should be done here, after _add_candidate_relations() so that
-            # removed relations are not re-added with `no-relation` label.
+
+            # Remove remaining relation duplicates.
+            # It should be done here, after _add_candidate_relations(),
+            # because with 'keep_none', first occurred relation has to be
+            # removed from 'arguments2relation', but if it is not here during _add_candidate_relations()
+            # relation with 'no_relation' label will be added instead.
             if self.handle_relations_with_same_arguments == "keep_none":
                 for arguments in arguments_duplicates:
                     rel = arguments2relation.pop(arguments)

--- a/src/pie_modules/taskmodules/re_text_classification_with_indices.py
+++ b/src/pie_modules/taskmodules/re_text_classification_with_indices.py
@@ -700,10 +700,17 @@ class RETextClassificationWithIndicesTaskModule(
                     # check if there are multiple relations with the same argument tuple
                     if arguments in arguments2relation:
                         prev_label = arguments2relation[arguments].label
+                        arguments_resolved = tuple(map(lambda x: x[1].resolve(), arguments))
+                        if prev_label == rel.label:
+                            logger.warning(
+                                f"doc.id={document.id}: Relation annotation `{rel.resolve()}` is duplicated. "
+                                f"We keep only one of them."
+                            )
+                            continue
                         arguments_duplicates.add(arguments)
                         if self.handle_relations_with_same_arguments == "keep_first":
                             logger.warning(
-                                f"doc.id={document.id}: there are multiple relations with the same arguments {arguments}: "
+                                f"doc.id={document.id}: there are multiple relations with the same arguments {arguments_resolved}: "
                                 f"previous label='{prev_label}' and current label='{rel.label}'. We only keep the first "
                                 f"occurring relation which has the label='{prev_label}'."
                             )
@@ -711,7 +718,7 @@ class RETextClassificationWithIndicesTaskModule(
                         # so that none of them are re-added as 'no-relation'
                         elif self.handle_relations_with_same_arguments == "keep_none":
                             logger.warning(
-                                f"doc.id={document.id}: there are multiple relations with the same arguments {arguments}: "
+                                f"doc.id={document.id}: there are multiple relations with the same arguments {arguments_resolved}: "
                                 f"previous label='{prev_label}' and current label='{rel.label}'. Both relations will be removed."
                             )
                         else:

--- a/src/pie_modules/taskmodules/re_text_classification_with_indices.py
+++ b/src/pie_modules/taskmodules/re_text_classification_with_indices.py
@@ -379,7 +379,7 @@ class RETextClassificationWithIndicesTaskModule(
         self.max_argument_distance_type = max_argument_distance_type
         self.max_window = max_window
         self.allow_discontinuous_text = allow_discontinuous_text
-        self.relations_with_same_arguments = handle_relations_with_same_arguments
+        self.handle_relations_with_same_arguments = handle_relations_with_same_arguments
         self.relations_with_same_arguments = relations_with_same_arguments
         self.argument_type_whitelist: Optional[List[Tuple[str, str]]] = None
 
@@ -701,7 +701,7 @@ class RETextClassificationWithIndicesTaskModule(
                     if arguments in arguments2relation:
                         prev_label = arguments2relation[arguments].label
                         arguments_duplicates.add(arguments)
-                        if self.relations_with_same_arguments == "keep_first":
+                        if self.handle_relations_with_same_arguments == "keep_first":
                             logger.warning(
                                 f"doc.id={document.id}: there are multiple relations with the same arguments {arguments}: "
                                 f"previous label='{prev_label}' and current label='{rel.label}'. We only keep the first "
@@ -709,7 +709,7 @@ class RETextClassificationWithIndicesTaskModule(
                             )
                         # if `keep_none`, first occurred relations are removed after _add_candidate_relations() call,
                         # so that none of them are re-added as 'no-relation'
-                        elif self.relations_with_same_arguments == "keep_none":
+                        elif self.handle_relations_with_same_arguments == "keep_none":
                             logger.warning(
                                 f"doc.id={document.id}: there are multiple relations with the same arguments {arguments}: "
                                 f"previous label='{prev_label}' and current label='{rel.label}'. Both relations will be removed."
@@ -736,7 +736,7 @@ class RETextClassificationWithIndicesTaskModule(
                 arguments2relation=arguments2relation, entities=entities, doc_id=document.id
             )
             # remove remaining relation duplicates
-            if self.relations_with_same_arguments == "keep_none":
+            if self.handle_relations_with_same_arguments == "keep_none":
                 for arguments in arguments_duplicates:
                     rel = arguments2relation.pop(arguments)
                     self.collect_relation("skipped_same_arguments", rel)

--- a/src/pie_modules/taskmodules/re_text_classification_with_indices.py
+++ b/src/pie_modules/taskmodules/re_text_classification_with_indices.py
@@ -303,6 +303,8 @@ class RETextClassificationWithIndicesTaskModule(
             combining all entities in the document and assigning the none_label. If the document already contains
             a relation with the entity pair, we do not add it again. If False, assume that the document already
             contains relation annotations including negative examples (i.e. relations with the none_label).
+        handle_relations_with_same_arguments: str, defaults to "keep_none". If "keep_none", all relations that
+            share same arguments will be removed. If "keep_first", first occurred duplicate will be kept.
     """
 
     PREPARED_ATTRIBUTES = ["labels", "entity_labels"]
@@ -339,6 +341,7 @@ class RETextClassificationWithIndicesTaskModule(
         add_global_attention_mask_to_input: bool = False,
         argument_type_whitelist: Optional[List[List[str]]] = None,
         relations_with_same_arguments: Optional[str] = "keep_none",
+        handle_relations_with_same_arguments: str = "keep_none",
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -376,6 +379,7 @@ class RETextClassificationWithIndicesTaskModule(
         self.max_argument_distance_type = max_argument_distance_type
         self.max_window = max_window
         self.allow_discontinuous_text = allow_discontinuous_text
+        self.relations_with_same_arguments = handle_relations_with_same_arguments
         self.relations_with_same_arguments = relations_with_same_arguments
         self.argument_type_whitelist: Optional[List[Tuple[str, str]]] = None
 
@@ -712,7 +716,7 @@ class RETextClassificationWithIndicesTaskModule(
                             )
                         else:
                             raise ValueError(
-                                "'relations_with_same_arguments' must be 'keep_first' or 'keep_none'."
+                                "'handle_relations_with_same_arguments' must be 'keep_first' or 'keep_none'."
                             )
                         self.collect_relation("skipped_same_arguments", rel)
                     else:

--- a/src/pie_modules/taskmodules/re_text_classification_with_indices.py
+++ b/src/pie_modules/taskmodules/re_text_classification_with_indices.py
@@ -700,7 +700,9 @@ class RETextClassificationWithIndicesTaskModule(
                     # check if there are multiple relations with the same argument tuple
                     if arguments in arguments2relation:
                         prev_label = arguments2relation[arguments].label
-                        arguments_resolved = tuple(map(lambda x: x[1].resolve(), arguments))
+                        arguments_resolved = tuple(
+                            map(lambda x: (x[0], x[1].resolve()), arguments)
+                        )
                         if prev_label == rel.label:
                             logger.warning(
                                 f"doc.id={document.id}: Relation annotation `{rel.resolve()}` is duplicated. "

--- a/tests/taskmodules/test_re_text_classification_with_indices.py
+++ b/tests/taskmodules/test_re_text_classification_with_indices.py
@@ -1045,14 +1045,15 @@ def test_collate_with_add_argument_indices(batch_with_argument_indices):
 
 @pytest.mark.parametrize("handle_relations_with_same_arguments", ["keep_first", "keep_none"])
 @pytest.mark.parametrize("add_candidate_relations", [False, True])
+@pytest.mark.parametrize("collect_statistics", [False, True])
 def test_encode_input_multiple_relations_for_same_arguments(
-    caplog, handle_relations_with_same_arguments, add_candidate_relations
+    caplog, handle_relations_with_same_arguments, add_candidate_relations, collect_statistics
 ):
     taskmodule = RETextClassificationWithIndicesTaskModule(
         relation_annotation="relations",
         tokenizer_name_or_path="bert-base-cased",
         handle_relations_with_same_arguments=handle_relations_with_same_arguments,
-        collect_statistics=True,
+        collect_statistics=collect_statistics,
         add_candidate_relations=add_candidate_relations,
     )
     document = TestDocument(text="A founded B.", id="test_doc")
@@ -1079,11 +1080,10 @@ def test_encode_input_multiple_relations_for_same_arguments(
         (rel.head.resolve(), rel.label, rel.tail.resolve()) for rel in candidate_relation
     ]
 
-    assert len(caplog.messages) == 2
+    assert len(caplog.messages) == 1
     if handle_relations_with_same_arguments == "keep_first":
-        assert (
-            caplog.messages[0]
-            == "doc.id=test_doc: there are multiple relations with the same arguments "
+        expected_warning = (
+            "doc.id=test_doc: there are multiple relations with the same arguments "
             "(('head', ('PER', 'A')), ('tail', ('PER', 'B'))), but different labels: "
             "['per:founded_by', 'per:founder', 'per:founded_by']. We only keep the first "
             "occurring relation which has the label='per:founded_by'."
@@ -1092,35 +1092,40 @@ def test_encode_input_multiple_relations_for_same_arguments(
             # with 'keep_first', only first relation occurred is kept ('per:founded_by').
             # full duplicate of 'per:founded_by' is removed and appears neither as available,
             # nor as skipped in statistics.
-            assert (
-                caplog.messages[1] == "statistics:\n"
-                "|                        |   per:founded_by |   per:founder |   all_relations |\n"
-                "|:-----------------------|-----------------:|--------------:|----------------:|\n"
-                "| available              |                1 |             1 |               2 |\n"
-                "| skipped_same_arguments |                0 |             1 |               1 |\n"
-                "| used                   |                1 |             0 |               1 |\n"
-                "| used %                 |              100 |             0 |              50 |"
-            )
             assert candidate_relation_tuples == [(("PER", "A"), "per:founded_by", ("PER", "B"))]
+            if collect_statistics:
+                assert (
+                    caplog.messages[0] == "statistics:\n"
+                    "|                        |   per:founded_by |   per:founder |   all_relations |\n"
+                    "|:-----------------------|-----------------:|--------------:|----------------:|\n"
+                    "| available              |                1 |             1 |               2 |\n"
+                    "| skipped_same_arguments |                0 |             1 |               1 |\n"
+                    "| used                   |                1 |             0 |               1 |\n"
+                    "| used %                 |              100 |             0 |              50 |"
+                )
+            else:
+                assert caplog.messages[0] == expected_warning
+
         else:
             # as above, but with candidate (negative) relations added
-            assert (
-                caplog.messages[1] == "statistics:\n"
-                "|                        |   no_relation |   per:founded_by |   per:founder |   all_relations |\n"
-                "|:-----------------------|--------------:|-----------------:|--------------:|----------------:|\n"
-                "| available              |             0 |                1 |             1 |               2 |\n"
-                "| skipped_same_arguments |             0 |                0 |             1 |               1 |\n"
-                "| used                   |             1 |                1 |             0 |               1 |\n"
-                "| used %                 |           inf |              100 |             0 |              50 |"
-            )
             assert candidate_relation_tuples == [
                 (("PER", "A"), "per:founded_by", ("PER", "B")),
                 (("PER", "B"), "no_relation", ("PER", "A")),
             ]
+            if collect_statistics:
+                assert (
+                    caplog.messages[0] == "statistics:\n"
+                    "|                        |   no_relation |   per:founded_by |   per:founder |   all_relations |\n"
+                    "|:-----------------------|--------------:|-----------------:|--------------:|----------------:|\n"
+                    "| available              |             0 |                1 |             1 |               2 |\n"
+                    "| skipped_same_arguments |             0 |                0 |             1 |               1 |\n"
+                    "| used                   |             1 |                1 |             0 |               1 |\n"
+                    "| used %                 |           inf |              100 |             0 |              50 |"
+                )
+
     elif handle_relations_with_same_arguments == "keep_none":
-        assert (
-            caplog.messages[0]
-            == "doc.id=test_doc: there are multiple relations with the same arguments "
+        expected_warning = (
+            "doc.id=test_doc: there are multiple relations with the same arguments "
             "(('head', ('PER', 'A')), ('tail', ('PER', 'B'))), but different labels: "
             "['per:founded_by', 'per:founder', 'per:founded_by']. All relations will be removed."
         )
@@ -1128,27 +1133,33 @@ def test_encode_input_multiple_relations_for_same_arguments(
             # with 'keep_none' both relations sharing same arguments are removed
             # full duplicate of 'per:founded_by' is removed and appears neither as available,
             # nor as skipped in statistics.
-            assert (
-                caplog.messages[1] == "statistics:\n"
-                "|                        |   per:founded_by |   per:founder |   all_relations |\n"
-                "|:-----------------------|-----------------:|--------------:|----------------:|\n"
-                "| available              |                1 |             1 |               2 |\n"
-                "| skipped_same_arguments |                1 |             1 |               2 |"
-            )
             assert candidate_relation_tuples == []
+            if collect_statistics:
+                assert (
+                    caplog.messages[0] == "statistics:\n"
+                    "|                        |   per:founded_by |   per:founder |   all_relations |\n"
+                    "|:-----------------------|-----------------:|--------------:|----------------:|\n"
+                    "| available              |                1 |             1 |               2 |\n"
+                    "| skipped_same_arguments |                1 |             1 |               2 |"
+                )
+            else:
+                assert caplog.messages[0] == expected_warning
         else:
             # all conflicting relations go into the same direction, so we can create a candidate (negative)
             # relation for the other direction.
-            assert (
-                caplog.messages[1] == "statistics:\n"
-                "|                        |   no_relation |   per:founded_by |   per:founder |   all_relations |\n"
-                "|:-----------------------|--------------:|-----------------:|--------------:|----------------:|\n"
-                "| available              |             0 |                1 |             1 |               2 |\n"
-                "| skipped_same_arguments |             0 |                1 |             1 |               2 |\n"
-                "| used                   |             1 |                0 |             0 |               0 |\n"
-                "| used %                 |           inf |                0 |             0 |               0 |"
-            )
             assert candidate_relation_tuples == [(("PER", "B"), "no_relation", ("PER", "A"))]
+            if collect_statistics:
+                assert (
+                    caplog.messages[0] == "statistics:\n"
+                    "|                        |   no_relation |   per:founded_by |   per:founder |   all_relations |\n"
+                    "|:-----------------------|--------------:|-----------------:|--------------:|----------------:|\n"
+                    "| available              |             0 |                1 |             1 |               2 |\n"
+                    "| skipped_same_arguments |             0 |                1 |             1 |               2 |\n"
+                    "| used                   |             1 |                0 |             0 |               0 |\n"
+                    "| used %                 |           inf |                0 |             0 |               0 |"
+                )
+            else:
+                assert caplog.messages[0] == expected_warning
 
 
 def test_encode_input_handle_relations_with_same_arguments_unknown_value(caplog):
@@ -1183,15 +1194,16 @@ def test_encode_input_handle_relations_with_same_arguments_unknown_value(caplog)
 
 @pytest.mark.parametrize("handle_relations_with_same_arguments", ["keep_first", "keep_none"])
 @pytest.mark.parametrize("add_candidate_relations", [False, True])
+@pytest.mark.parametrize("collect_statistics", [False, True])
 def test_encode_input_duplicated_relations(
-    caplog, handle_relations_with_same_arguments, add_candidate_relations
+    caplog, handle_relations_with_same_arguments, add_candidate_relations, collect_statistics
 ):
     taskmodule = RETextClassificationWithIndicesTaskModule(
         relation_annotation="relations",
         tokenizer_name_or_path="bert-base-cased",
         handle_relations_with_same_arguments=handle_relations_with_same_arguments,
         add_candidate_relations=add_candidate_relations,
-        collect_statistics=True,
+        collect_statistics=collect_statistics,
     )
     document = TestDocument(text="A founded B.", id="test_doc")
     document.entities.append(LabeledSpan(start=0, end=1, label="PER"))
@@ -1210,7 +1222,10 @@ def test_encode_input_duplicated_relations(
 
     with caplog.at_level(logging.INFO):
         taskmodule.show_statistics()
-    assert len(caplog.messages) == 2
+    if collect_statistics:
+        assert len(caplog.messages) == 2
+    else:
+        assert len(caplog.messages) == 1
     assert (
         caplog.messages[0] == "doc.id=test_doc: Relation annotation "
         "`('per:founded_by', (('PER', 'A'), ('PER', 'B')))` is duplicated. We keep "
@@ -1227,24 +1242,26 @@ def test_encode_input_duplicated_relations(
             (("PER", "A"), "per:founded_by", ("PER", "B")),
             (("PER", "B"), "no_relation", ("PER", "A")),
         ]
-        assert (
-            caplog.messages[1] == "statistics:\n"
-            "|           |   no_relation |   per:founded_by |   all_relations |\n"
-            "|:----------|--------------:|-----------------:|----------------:|\n"
-            "| available |             0 |                1 |               1 |\n"
-            "| used      |             1 |                1 |               1 |\n"
-            "| used %    |           inf |              100 |             100 |"
-        )
+        if collect_statistics:
+            assert (
+                caplog.messages[-1] == "statistics:\n"
+                "|           |   no_relation |   per:founded_by |   all_relations |\n"
+                "|:----------|--------------:|-----------------:|----------------:|\n"
+                "| available |             0 |                1 |               1 |\n"
+                "| used      |             1 |                1 |               1 |\n"
+                "| used %    |           inf |              100 |             100 |"
+            )
     else:
         assert candidate_relation_tuples == [(("PER", "A"), "per:founded_by", ("PER", "B"))]
-        assert (
-            caplog.messages[1] == "statistics:\n"
-            "|           |   per:founded_by |\n"
-            "|:----------|-----------------:|\n"
-            "| available |                1 |\n"
-            "| used      |                1 |\n"
-            "| used %    |              100 |"
-        )
+        if collect_statistics:
+            assert (
+                caplog.messages[-1] == "statistics:\n"
+                "|           |   per:founded_by |\n"
+                "|:----------|-----------------:|\n"
+                "| available |                1 |\n"
+                "| used      |                1 |\n"
+                "| used %    |              100 |"
+            )
 
 
 def test_encode_input_argument_role_unknown(documents):

--- a/tests/taskmodules/test_re_text_classification_with_indices.py
+++ b/tests/taskmodules/test_re_text_classification_with_indices.py
@@ -1095,7 +1095,7 @@ def test_encode_input_multiple_relations_for_same_arguments(
                 caplog.messages[1]
                 == "doc.id=multiple_relations_for_same_arguments: Relation annotation "
                 "`('per:founded_by', (('PER', 'A'), ('PER', 'B')))` is duplicated. We keep "
-                "only one of them."
+                "only one of them. Duplicate won't appear in statistics either as 'available' or as skipped."
             )
             # with 'keep_first', only first relation occurred is kept ('per:founded_by').
             # full duplicate of 'per:founded_by' is removed and appears neither as available, nor as skipped in statistics.
@@ -1124,8 +1124,8 @@ def test_encode_input_multiple_relations_for_same_arguments(
             assert (
                 caplog.messages[1]
                 == "doc.id=multiple_relations_for_same_arguments: Relation annotation "
-                "`('per:founded_by', (('PER', 'A'), ('PER', 'B')))` is duplicated. "
-                "We keep only one of them."
+                "`('per:founded_by', (('PER', 'A'), ('PER', 'B')))` is duplicated. We keep "
+                "only one of them. Duplicate won't appear in statistics either as 'available' or as skipped."
             )
             # with 'keep_none' both relations sharing same arguments are removed
             # full duplicate of 'per:founded_by' is removed and appears neither as available, nor as skipped in statistics.
@@ -1168,7 +1168,7 @@ def test_encode_input_duplicated_relations(caplog, handle_relations_with_same_ar
     assert (
         caplog.messages[0] == "doc.id=multiple_relations_for_same_arguments: Relation annotation "
         "`('per:founded_by', (('PER', 'A'), ('PER', 'B')))` is duplicated. We keep "
-        "only one of them."
+        "only one of them. Duplicate won't appear in statistics either as 'available' or as skipped."
     )
     # equally for 'keep_first' and 'keep_last', full duplicates are not affected and do not appear in statistics, but still
     # generate a warning.

--- a/tests/taskmodules/test_re_text_classification_with_indices.py
+++ b/tests/taskmodules/test_re_text_classification_with_indices.py
@@ -1086,26 +1086,18 @@ def test_encode_input_multiple_relations_for_same_arguments(
         if handle_relations_with_same_arguments == "keep_first":
             assert (
                 caplog.messages[0]
-                == "doc.id=multiple_relations_for_same_arguments: there are multiple relations with the same arguments "
-                "(('head', LabeledSpan(start=0, end=1, label='PER', score=1.0)), "
-                "('tail', LabeledSpan(start=10, end=11, label='PER', score=1.0))): previous label='per:founded_by' "
-                "and current label='per:founder'. We only keep the first occurring relation which has the "
-                "label='per:founded_by'."
+                == "doc.id=multiple_relations_for_same_arguments: there are multiple relations with the same arguments (('PER', 'A'), ('PER', 'B')): previous label='per:founded_by' and current label='per:founder'. We only keep the first occurring relation which has the label='per:founded_by'."
             )
             assert (
                 caplog.messages[1]
-                == "doc.id=multiple_relations_for_same_arguments: there are multiple relations with the same arguments "
-                "(('head', LabeledSpan(start=0, end=1, label='PER', score=1.0)), "
-                "('tail', LabeledSpan(start=10, end=11, label='PER', score=1.0))): previous label='per:founded_by' "
-                "and current label='per:founded_by'. We only keep the first occurring relation which has the "
-                "label='per:founded_by'."
+                == "doc.id=multiple_relations_for_same_arguments: Relation annotation `('per:founded_by', (('PER', 'A'), ('PER', 'B')))` is duplicated. We keep only one of them."
             )
             assert (
                 caplog.messages[2] == "statistics:\n"
                 "|                        |   per:founded_by |   per:founder |   all_relations |\n"
                 "|:-----------------------|-----------------:|--------------:|----------------:|\n"
                 "| available              |                1 |             1 |               2 |\n"
-                "| skipped_same_arguments |                1 |             1 |               2 |\n"
+                "| skipped_same_arguments |                0 |             1 |               1 |\n"
                 "| used                   |                1 |             0 |               1 |\n"
                 "| used %                 |              100 |             0 |              50 |"
             )
@@ -1118,16 +1110,13 @@ def test_encode_input_multiple_relations_for_same_arguments(
             assert (
                 caplog.messages[0]
                 == "doc.id=multiple_relations_for_same_arguments: there are multiple relations with the same arguments "
-                "(('head', LabeledSpan(start=0, end=1, label='PER', score=1.0)), "
-                "('tail', LabeledSpan(start=10, end=11, label='PER', score=1.0))): previous label='per:founded_by' "
-                "and current label='per:founder'. Both relations will be removed."
+                "(('PER', 'A'), ('PER', 'B')): previous label='per:founded_by' and current label='per:founder'. "
+                "Both relations will be removed."
             )
             assert (
                 caplog.messages[1]
-                == "doc.id=multiple_relations_for_same_arguments: there are multiple relations with the same arguments "
-                "(('head', LabeledSpan(start=0, end=1, label='PER', score=1.0)), "
-                "('tail', LabeledSpan(start=10, end=11, label='PER', score=1.0))): previous label='per:founded_by' "
-                "and current label='per:founded_by'. Both relations will be removed."
+                == "doc.id=multiple_relations_for_same_arguments: Relation annotation `('per:founded_by', "
+                "(('PER', 'A'), ('PER', 'B')))` is duplicated. We keep only one of them."
             )
             assert (
                 caplog.messages[2] == "statistics:\n"

--- a/tests/taskmodules/test_re_text_classification_with_indices.py
+++ b/tests/taskmodules/test_re_text_classification_with_indices.py
@@ -1086,11 +1086,16 @@ def test_encode_input_multiple_relations_for_same_arguments(
         if handle_relations_with_same_arguments == "keep_first":
             assert (
                 caplog.messages[0]
-                == "doc.id=multiple_relations_for_same_arguments: there are multiple relations with the same arguments (('PER', 'A'), ('PER', 'B')): previous label='per:founded_by' and current label='per:founder'. We only keep the first occurring relation which has the label='per:founded_by'."
+                == "doc.id=multiple_relations_for_same_arguments: there are multiple relations with the "
+                "same arguments (('head', ('PER', 'A')), ('tail', ('PER', 'B'))): previous "
+                "label='per:founded_by' and current label='per:founder'. We only keep the first "
+                "occurring relation which has the label='per:founded_by'."
             )
             assert (
                 caplog.messages[1]
-                == "doc.id=multiple_relations_for_same_arguments: Relation annotation `('per:founded_by', (('PER', 'A'), ('PER', 'B')))` is duplicated. We keep only one of them."
+                == "doc.id=multiple_relations_for_same_arguments: Relation annotation "
+                "`('per:founded_by', (('PER', 'A'), ('PER', 'B')))` is duplicated. We keep "
+                "only one of them."
             )
             assert (
                 caplog.messages[2] == "statistics:\n"
@@ -1109,14 +1114,16 @@ def test_encode_input_multiple_relations_for_same_arguments(
         elif handle_relations_with_same_arguments == "keep_none":
             assert (
                 caplog.messages[0]
-                == "doc.id=multiple_relations_for_same_arguments: there are multiple relations with the same arguments "
-                "(('PER', 'A'), ('PER', 'B')): previous label='per:founded_by' and current label='per:founder'. "
-                "Both relations will be removed."
+                == "doc.id=multiple_relations_for_same_arguments: there are multiple relations "
+                "with the same arguments (('head', ('PER', 'A')), ('tail', ('PER', 'B'))): "
+                "previous label='per:founded_by' and current label='per:founder'. Both relations "
+                "will be removed."
             )
             assert (
                 caplog.messages[1]
-                == "doc.id=multiple_relations_for_same_arguments: Relation annotation `('per:founded_by', "
-                "(('PER', 'A'), ('PER', 'B')))` is duplicated. We keep only one of them."
+                == "doc.id=multiple_relations_for_same_arguments: Relation annotation "
+                "`('per:founded_by', (('PER', 'A'), ('PER', 'B')))` is duplicated. "
+                "We keep only one of them."
             )
             assert (
                 caplog.messages[2] == "statistics:\n"

--- a/tests/taskmodules/test_re_text_classification_with_indices.py
+++ b/tests/taskmodules/test_re_text_classification_with_indices.py
@@ -1074,32 +1074,26 @@ def test_encode_input_multiple_relations_for_same_arguments(
 
     with caplog.at_level(logging.INFO):
         taskmodule.show_statistics()
-    assert len(caplog.messages) == 3
     candidate_relation = [enc.metadata["candidate_annotation"] for enc in encodings]
     candidate_relation_tuples = [
         (rel.head.resolve(), rel.label, rel.tail.resolve()) for rel in candidate_relation
     ]
 
+    assert len(caplog.messages) == 2
     if handle_relations_with_same_arguments == "keep_first":
         assert (
             caplog.messages[0]
             == "doc.id=test_doc: there are multiple relations with the same arguments "
-            "(('head', ('PER', 'A')), ('tail', ('PER', 'B'))): previous "
-            "label='per:founded_by' and current label='per:founder'. We only keep the "
-            "first occurring relation which has the label='per:founded_by'."
-        )
-        assert (
-            caplog.messages[1]
-            == "doc.id=test_doc: Relation annotation `('per:founded_by', (('PER', 'A'), ('PER', 'B')))` "
-            "is duplicated. We keep only one of them. Duplicate won't appear in statistics either as "
-            "'available' or as skipped."
+            "(('head', ('PER', 'A')), ('tail', ('PER', 'B'))), but different labels: "
+            "['per:founded_by', 'per:founder', 'per:founded_by']. We only keep the first "
+            "occurring relation which has the label='per:founded_by'."
         )
         if not add_candidate_relations:
             # with 'keep_first', only first relation occurred is kept ('per:founded_by').
             # full duplicate of 'per:founded_by' is removed and appears neither as available,
             # nor as skipped in statistics.
             assert (
-                caplog.messages[2] == "statistics:\n"
+                caplog.messages[1] == "statistics:\n"
                 "|                        |   per:founded_by |   per:founder |   all_relations |\n"
                 "|:-----------------------|-----------------:|--------------:|----------------:|\n"
                 "| available              |                1 |             1 |               2 |\n"
@@ -1111,7 +1105,7 @@ def test_encode_input_multiple_relations_for_same_arguments(
         else:
             # as above, but with candidate (negative) relations added
             assert (
-                caplog.messages[2] == "statistics:\n"
+                caplog.messages[1] == "statistics:\n"
                 "|                        |   no_relation |   per:founded_by |   per:founder |   all_relations |\n"
                 "|:-----------------------|--------------:|-----------------:|--------------:|----------------:|\n"
                 "| available              |             0 |                1 |             1 |               2 |\n"
@@ -1127,21 +1121,15 @@ def test_encode_input_multiple_relations_for_same_arguments(
         assert (
             caplog.messages[0]
             == "doc.id=test_doc: there are multiple relations with the same arguments "
-            "(('head', ('PER', 'A')), ('tail', ('PER', 'B'))): previous label='per:founded_by' "
-            "and current label='per:founder'. Both relations will be removed."
-        )
-        assert (
-            caplog.messages[1]
-            == "doc.id=test_doc: Relation annotation `('per:founded_by', (('PER', 'A'), ('PER', 'B')))` "
-            "is duplicated. We keep only one of them. Duplicate won't appear in statistics either "
-            "as 'available' or as skipped."
+            "(('head', ('PER', 'A')), ('tail', ('PER', 'B'))), but different labels: "
+            "['per:founded_by', 'per:founder', 'per:founded_by']. All relations will be removed."
         )
         if not add_candidate_relations:
             # with 'keep_none' both relations sharing same arguments are removed
             # full duplicate of 'per:founded_by' is removed and appears neither as available,
             # nor as skipped in statistics.
             assert (
-                caplog.messages[2] == "statistics:\n"
+                caplog.messages[1] == "statistics:\n"
                 "|                        |   per:founded_by |   per:founder |   all_relations |\n"
                 "|:-----------------------|-----------------:|--------------:|----------------:|\n"
                 "| available              |                1 |             1 |               2 |\n"
@@ -1152,7 +1140,7 @@ def test_encode_input_multiple_relations_for_same_arguments(
             # all conflicting relations go into the same direction, so we can create a candidate (negative)
             # relation for the other direction.
             assert (
-                caplog.messages[2] == "statistics:\n"
+                caplog.messages[1] == "statistics:\n"
                 "|                        |   no_relation |   per:founded_by |   per:founder |   all_relations |\n"
                 "|:-----------------------|--------------:|-----------------:|--------------:|----------------:|\n"
                 "| available              |             0 |                1 |             1 |               2 |\n"


### PR DESCRIPTION
If there are multiple relations with same pair of arguments, `handle_relations_with_same_arguments` defines if we remove both of them (`keep_none`) or keep the first one (`keep_first`). Full duplicates (if relation label is also the same) are not affected by this, one relation will be kept and a warning shown.

Note that if `collect_statistics=True`, final statistics do not include such "full duplicates" either as 'available' nor as 'skipped'. Also, **warnings about elements collected in the statistics**, e.g. skipped relations with same arguments, **will not be shown if `collect_statistics=True`.**
 
**This PR changes the default behavior to `keep_none`, that's why is labeled as `breaking` (previously it was implicitly `keep_first`).** Doing so prevents the model from learning conflicting relations and gaining biases for arbitrary 'first' relation occurred. 

TODO:
- [x] Test new behaviour on a downstream task (e.g. runs with 3 seeds at drugprot)

Note: `keep_none` reduces train instances count of drugprot by 199 (1,16%) from 17058 to 16859.
metric | baseline |  with keep_none 
-- | -- | -- 
quality (micro f1) | 0.7737 (±0.0042) |  0.7653 (±0.0022) 
Inference time | 13.5 (±0.3) | 11.2 (±0.5) 