### PR TITLE
CI: define only major version for all actions from Github

### DIFF
--- a/.github/workflows/code-quality-main.yaml
+++ b/.github/workflows/code-quality-main.yaml
@@ -16,10 +16,10 @@ jobs:
       #       check-out repo and set-up python
       #----------------------------------------------
       - name: Check out repository
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4
       - name: Set up Python 3.9
         id: setup-python
-        uses: actions/setup-python@v5.2.0
+        uses: actions/setup-python@v5
         with:
           python-version: "3.9"
 
@@ -38,7 +38,7 @@ jobs:
       #----------------------------------------------
       - name: Load cached venv
         id: cached-poetry-dependencies
-        uses: actions/cache@v4.1.0
+        uses: actions/cache@v4
         with:
           path: .venv
           key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
@@ -51,4 +51,4 @@ jobs:
         run: poetry install --no-interaction --no-root
 
       - name: Run pre-commits
-        uses: pre-commit/action@v3.0.1
+        uses: pre-commit/action@v3

--- a/.github/workflows/code-quality-main.yaml
+++ b/.github/workflows/code-quality-main.yaml
@@ -51,4 +51,4 @@ jobs:
         run: poetry install --no-interaction --no-root
 
       - name: Run pre-commits
-        uses: pre-commit/action@v3
+        uses: pre-commit/action@v3.0.1

--- a/.github/workflows/code-quality-pr.yaml
+++ b/.github/workflows/code-quality-pr.yaml
@@ -68,6 +68,6 @@ jobs:
       # run pre-commit on modified files
       #----------------------------------------------
       - name: Run pre-commits
-        uses: pre-commit/action@v3
+        uses: pre-commit/action@v3.0.1
         with:
           extra_args: --files ${{ steps.file_changes.outputs.files}}

--- a/.github/workflows/code-quality-pr.yaml
+++ b/.github/workflows/code-quality-pr.yaml
@@ -19,10 +19,10 @@ jobs:
       #       check-out repo and set-up python
       #----------------------------------------------
       - name: Check out repository
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4
       - name: Set up Python 3.9
         id: setup-python
-        uses: actions/setup-python@v5.2.0
+        uses: actions/setup-python@v5
         with:
           python-version: "3.9"
 
@@ -41,7 +41,7 @@ jobs:
       #----------------------------------------------
       - name: Load cached venv
         id: cached-poetry-dependencies
-        uses: actions/cache@v4.1.0
+        uses: actions/cache@v4
         with:
           path: .venv
           key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
@@ -68,6 +68,6 @@ jobs:
       # run pre-commit on modified files
       #----------------------------------------------
       - name: Run pre-commits
-        uses: pre-commit/action@v3.0.1
+        uses: pre-commit/action@v3
         with:
           extra_args: --files ${{ steps.file_changes.outputs.files}}

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -10,7 +10,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Check out the repository
-              uses: actions/checkout@v4.2.1
+              uses: actions/checkout@v4
 
             - name: Run Labeler
               uses: crazy-max/ghaction-github-labeler@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,12 +11,12 @@ jobs:
         runs-on: ubuntu-latest
         steps:
           - name: Check out the repository
-            uses: actions/checkout@v4.2.1
+            uses: actions/checkout@v4
             with:
                 fetch-depth: 2
 
           - name: Set up Python
-            uses: actions/setup-python@v5.2.0
+            uses: actions/setup-python@v5
             with:
                 python-version: "3.9"
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,10 +24,10 @@ jobs:
       #       check-out repo and set-up python
       #----------------------------------------------
       - name: Check out repository
-        uses: actions/checkout@v4.2.1
+        uses: actions/checkout@v4
       - name: Set up python
         id: setup-python
-        uses: actions/setup-python@v5.2.0
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -46,7 +46,7 @@ jobs:
       #----------------------------------------------
       - name: Load cached venv
         id: cached-poetry-dependencies
-        uses: actions/cache@v3.1.0
+        uses: actions/cache@v4.1.0
         with:
           path: .venv
           key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -46,7 +46,7 @@ jobs:
       #----------------------------------------------
       - name: Load cached venv
         id: cached-poetry-dependencies
-        uses: actions/cache@v4.1.0
+        uses: actions/cache@v4
         with:
           path: .venv
           key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -46,7 +46,7 @@ jobs:
       #----------------------------------------------
       - name: Load cached venv
         id: cached-poetry-dependencies
-        uses: actions/cache@v4.1.0
+        uses: actions/cache@v3.1.0
         with:
           path: .venv
           key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}


### PR DESCRIPTION
especially for `actions/cache` to fix the version issue, see https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down for context

**Note that our actions did not succeed although we use `actions/cache >= 4` (`v4.2.1`).**

Same as https://github.com/ArneBinder/pie-datasets/pull/170.