### PR TITLE
`TokenClassificationModelWithSeq2SeqEncoderAndCrf`: concatenate sequence segments from same batch 

### DIFF
--- a/tests/models/test_simple_token_classification.py
+++ b/tests/models/test_simple_token_classification.py
@@ -34,6 +34,7 @@ def taskmodule_config():
         "tokenize_kwargs": None,
         "pad_kwargs": None,
         "log_precision_recall_metrics": True,
+        "inputs_key_document_indices": None,
     }
 
 

--- a/tests/models/test_token_classification_with_seq2seq_encoder_and_crf.py
+++ b/tests/models/test_token_classification_with_seq2seq_encoder_and_crf.py
@@ -35,6 +35,7 @@ def taskmodule_config():
         "tokenize_kwargs": None,
         "pad_kwargs": None,
         "log_precision_recall_metrics": True,
+        "inputs_key_document_indices": None,
     }
 
 


### PR DESCRIPTION
TODO: explain approach

usage:
 - model config: wrap the seq2seq encoder in `concatenate_sequences` (use the usual seq2seq config as value of `module`)
 - taskmodule config: set `inputs_key_document_indices=seq2seq_encoder_sequence_ids`
 - **don't shuffle data during training!**