### PR TITLE
add parameter `combine_token_scores_method` for `LabeledSpanExtractionByTokenClassificationTaskModule`

### DIFF
--- a/tests/models/test_simple_token_classification.py
+++ b/tests/models/test_simple_token_classification.py
@@ -33,6 +33,7 @@ def taskmodule_config():
         "include_ill_formed_predictions": True,
         "tokenize_kwargs": None,
         "pad_kwargs": None,
+        "combine_token_scores_method": "mean",
         "log_precision_recall_metrics": True,
     }
 

--- a/tests/models/test_token_classification_with_seq2seq_encoder_and_crf.py
+++ b/tests/models/test_token_classification_with_seq2seq_encoder_and_crf.py
@@ -32,6 +32,7 @@ def taskmodule_config():
         "label_pad_id": -100,
         "labels": ["ORG", "PER"],
         "include_ill_formed_predictions": True,
+        "combine_token_scores_method": "mean",
         "tokenize_kwargs": None,
         "pad_kwargs": None,
         "log_precision_recall_metrics": True,


### PR DESCRIPTION
From the docstring:
 
`combine_token_scores_method`: Method to combine the token scores to a span score. Options are "mean", "max", "min", and "product". Default: "mean".

Note that "mean" was the implicit behavior until now, so this is **not** breaking. 