### PR TITLE
`PointerNetworkTaskModuleForEnd2EndRE`: outsource remaining encoder-decoder specific logic

### DIFF
--- a/src/pie_modules/taskmodules/common/interfaces.py
+++ b/src/pie_modules/taskmodules/common/interfaces.py
@@ -1,5 +1,5 @@
 import abc
-from typing import Any, Dict, Generic, List, Optional, Tuple, TypeVar
+from typing import Any, Dict, Generic, List, Optional, Set, Tuple, TypeVar
 
 from pytorch_ie import Annotation
 
@@ -32,3 +32,17 @@ class AnnotationEncoderDecoder(abc.ABC, Generic[A, AE]):
     @abc.abstractmethod
     def decode(self, encoding: AE, metadata: Optional[Dict[str, Any]] = None) -> A:
         pass
+
+    def build_decoding_constraints(
+        self, partial_encoding: AE
+    ) -> Tuple[Optional[Any], Optional[Any]]:
+        """Given a partial encoding, build the constraints for the next encoding step.
+
+        Returns:
+            - A tuple of two elements:
+                - The first element is a set of positive constraints for the decoder.
+                - The second element is a set of negative constraints for the decoder.
+        """
+        raise NotImplementedError(
+            "build_decoder_constraints is not implemented for this encoder/decoder."
+        )

--- a/src/pie_modules/taskmodules/common/interfaces.py
+++ b/src/pie_modules/taskmodules/common/interfaces.py
@@ -1,5 +1,5 @@
 import abc
-from typing import Any, Dict, Generic, List, Optional, Set, Tuple, TypeVar
+from typing import Any, Dict, Generic, List, Optional, Tuple, TypeVar
 
 from pytorch_ie import Annotation
 

--- a/src/pie_modules/taskmodules/common/interfaces.py
+++ b/src/pie_modules/taskmodules/common/interfaces.py
@@ -57,7 +57,7 @@ class AnnotationEncoderDecoder(abc.ABC, Generic[A, AE]):
         Returns:
             - A tuple of three elements:
                 - A list of encoded annotations.
-                - A dictionary mapping error messages to their counts.
+                - A dictionary mapping error types to their counts.
                 - The remaining encoding after parsing.
         """
         raise NotImplementedError("parse is not implemented for this encoder/decoder.")

--- a/src/pie_modules/taskmodules/common/interfaces.py
+++ b/src/pie_modules/taskmodules/common/interfaces.py
@@ -46,3 +46,18 @@ class AnnotationEncoderDecoder(abc.ABC, Generic[A, AE]):
         raise NotImplementedError(
             "build_decoder_constraints is not implemented for this encoder/decoder."
         )
+
+    def parse(self, encoding: AE) -> Tuple[List[A], Dict[str, int], AE]:
+        """Parse the encoding and return a list of annotations. This should be error tolerant and
+        return all annotations that can be parsed and the remaining encoding.
+
+        Args:
+            encoding: The encoding to parse. Can be incomplete.
+
+        Returns:
+            - A tuple of three elements:
+                - A list of encoded annotations.
+                - A dictionary mapping error messages to their counts.
+                - The remaining encoding after parsing.
+        """
+        raise NotImplementedError("parse is not implemented for this encoder/decoder.")

--- a/src/pie_modules/taskmodules/pointer_network/annotation_encoder_decoder.py
+++ b/src/pie_modules/taskmodules/pointer_network/annotation_encoder_decoder.py
@@ -4,8 +4,7 @@ from typing import Any, Dict, List, Optional, Set, Tuple
 
 from pytorch_ie.annotations import BinaryRelation, LabeledSpan, Span
 
-from pie_modules.taskmodules.common import AnnotationEncoderDecoder
-from pie_modules.taskmodules.common.interfaces import DecodingException
+from pie_modules.taskmodules.common import AnnotationEncoderDecoder, DecodingException
 
 logger = logging.getLogger(__name__)
 

--- a/src/pie_modules/taskmodules/pointer_network_for_end2end_re.py
+++ b/src/pie_modules/taskmodules/pointer_network_for_end2end_re.py
@@ -689,7 +689,7 @@ class PointerNetworkTaskModuleForEnd2EndRE(
             for allowed_id in allowed_ids:
                 result[allowed_id] = 1
         elif disallowed_ids is not None:
-            for id in range(input_len + self.pointer_offset):
+            for id in range(len(result)):
                 if id not in disallowed_ids:
                     result[id] = 1
         else:

--- a/src/pie_modules/taskmodules/pointer_network_for_end2end_re.py
+++ b/src/pie_modules/taskmodules/pointer_network_for_end2end_re.py
@@ -39,7 +39,7 @@ from pie_modules.documents import (
 
 from ..document.processing import token_based_document_to_text_based, tokenize_document
 from ..utils import resolve_type
-from .common import BatchableMixin, DecodingException, get_first_occurrence_index
+from .common import BatchableMixin, get_first_occurrence_index
 from .metrics import (
     PrecisionRecallAndF1ForLabeledAnnotations,
     WrappedLayerMetricsWithUnbatchAndDecodeWithErrorsFunction,

--- a/src/pie_modules/taskmodules/pointer_network_for_end2end_re.py
+++ b/src/pie_modules/taskmodules/pointer_network_for_end2end_re.py
@@ -658,6 +658,20 @@ class PointerNetworkTaskModuleForEnd2EndRE(
         previous_ids: List[int],
         input_len: int,
     ) -> torch.LongTensor:
+        """Build a constraint for the decoder. The constraint is a binary mask that indicates which
+        ids are allowed to be predicted in the next decoding step. The mask is of size input_len +
+        pointer_offset, where input_len is the length of the input sequence and pointer_offset is
+        the number of labels and special tokens. Uses the relation_encoder_decoder to build the
+        actual constraints.
+
+        Args:
+            previous_ids: previously decoded ids
+            input_len: length of the input sequence
+
+        Returns:
+            A binary mask of size input_len + pointer_offset, where 1 indicates that the id is
+            allowed to be predicted next, and 0 indicates that the id is not allowed to be predicted next.
+        """
         result: torch.LongTensor = torch.zeros(input_len + self.pointer_offset, dtype=torch.int64)
         if self.eos_id in previous_ids:
             # once eos is predicted, only allow padding


### PR DESCRIPTION
Move all remaining logic that is specific to the `relation_encoder_decoder` into `BinaryRelationEncoderDecoder`, i.e., the creation of constraints and parsing of partial / erroneous encodings.

This PR:
 - adds the interface methods to `AnnotationEncoderDecoder`:
    - `build_decoding_constraints`
    - `parse`
 - adds implements to `BinaryRelationEncoderDecoder`
 - in `PointerNetworkTaskModuleForEnd2EndRE`:
     - removes `build_constraints` but uses `self.relation_encoder_decoder.build_decoding_constraints` (in `._build_constraint`) instead 
     - removes `decode_relations` but uses `self.relation_encoder_decoder.parse` instead

Note that the implementations of `BinaryRelationEncoderDecoder.build_decoding_constraints` and `.parse` are **not complete**, they do not cover all options for `mode` and do not work with arbitrary `head_encoder_decoder` / `tail_encoder_decoder`. But they cover the same amount of features that were implemented until now.

This is a first step for a simplified version of #63. Especially, it is not breaking. Remaining steps would be:
 - implement `MultiSpanEncoderDecoder`,
 - adjust `_post_prepare` to use it as `relation_encoder_decoder` (if the layer of `document_type` with `span_layer_name` is of type `LabeledMultiSpan`), and
 - adjust `cmp_src_rel` (relation sorting) to work with `LabeledMultiSpan`.
 - (optional: add reversed relations logic)

This will also allow to use this taskmodule as a blueprint for pointer based setups that handle *any* annotation structures. This will require to overwrite:
 - `_post_prepare`,
 - `encode_annotations`, and
 - `decode_annotations`.