### PR TITLE
streamline imports from `pytorch-ie`

### DIFF
--- a/src/pie_modules/document/processing/merge_multi_spans.py
+++ b/src/pie_modules/document/processing/merge_multi_spans.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Generic, TypeVar, get_args
 
-from pytorch_ie import Annotation, Document
+from pytorch_ie.core import Annotation, Document
 
 from pie_modules.annotations import MultiSpan, Span
 

--- a/src/pie_modules/document/processing/merge_spans_via_relation.py
+++ b/src/pie_modules/document/processing/merge_spans_via_relation.py
@@ -1,8 +1,7 @@
 import logging
 from typing import Optional, Sequence, Set, Tuple, TypeVar, Union
 
-from pytorch_ie import AnnotationLayer
-from pytorch_ie.core import Document
+from pytorch_ie.core import AnnotationLayer, Document
 
 from pie_modules.annotations import BinaryRelation, LabeledMultiSpan, LabeledSpan
 from pie_modules.utils import resolve_type

--- a/src/pie_modules/document/processing/regex_partitioner.py
+++ b/src/pie_modules/document/processing/regex_partitioner.py
@@ -6,9 +6,10 @@ import re
 import statistics
 from typing import Any, Callable, Iterable, Iterator, Match, TypeVar
 
-from pytorch_ie.annotations import LabeledSpan
 from pytorch_ie.core import EnterDatasetMixin, ExitDatasetMixin
-from pytorch_ie.documents import TextBasedDocument
+
+from pie_modules.annotations import LabeledSpan
+from pie_modules.documents import TextBasedDocument
 
 logger = logging.getLogger(__name__)
 

--- a/src/pie_modules/document/processing/relation_argument_sorter.py
+++ b/src/pie_modules/document/processing/relation_argument_sorter.py
@@ -3,10 +3,9 @@ from __future__ import annotations
 import logging
 from typing import TypeVar
 
-from pytorch_ie.annotations import BinaryRelation, LabeledSpan
 from pytorch_ie.core import Annotation, AnnotationList, Document
 
-from pie_modules.annotations import LabeledMultiSpan
+from pie_modules.annotations import BinaryRelation, LabeledMultiSpan, LabeledSpan
 
 logger = logging.getLogger(__name__)
 

--- a/src/pie_modules/document/processing/relation_argument_sorter.py
+++ b/src/pie_modules/document/processing/relation_argument_sorter.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from typing import TypeVar
 
-from pytorch_ie.core import Annotation, AnnotationList, Document
+from pytorch_ie.core import Annotation, AnnotationLayer, Document
 
 from pie_modules.annotations import BinaryRelation, LabeledMultiSpan, LabeledSpan
 
@@ -75,7 +75,7 @@ class RelationArgumentSorter:
         self.verbose = verbose
 
     def __call__(self, doc: D) -> D:
-        rel_layer: AnnotationList[BinaryRelation] = doc[self.relation_layer]
+        rel_layer: AnnotationLayer[BinaryRelation] = doc[self.relation_layer]
         args2relations: dict[tuple[LabeledSpan, ...], BinaryRelation] = {
             get_relation_args(rel): rel for rel in rel_layer
         }

--- a/src/pie_modules/document/processing/sentence_splitter.py
+++ b/src/pie_modules/document/processing/sentence_splitter.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import logging
 from typing import TypeVar
 
-from pytorch_ie.annotations import LabeledSpan
-from pytorch_ie.documents import TextDocumentWithLabeledPartitions
+from pie_modules.annotations import LabeledSpan
+from pie_modules.documents import TextDocumentWithLabeledPartitions
 
 logger = logging.getLogger(__name__)
 

--- a/src/pie_modules/document/processing/text_pair.py
+++ b/src/pie_modules/document/processing/text_pair.py
@@ -6,15 +6,13 @@ from collections.abc import Iterator
 from itertools import chain
 from typing import Dict, Iterable, List, Optional, Tuple, TypeVar
 
-from pytorch_ie.annotations import LabeledSpan, Span
-from pytorch_ie.documents import (
-    TextDocumentWithLabeledSpansAndBinaryRelations,
-    TextDocumentWithLabeledSpansBinaryRelationsAndLabeledPartitions,
-)
 from tqdm import tqdm
 
+from pie_modules.annotations import LabeledSpan, Span
 from pie_modules.documents import (
     BinaryCorefRelation,
+    TextDocumentWithLabeledSpansAndBinaryRelations,
+    TextDocumentWithLabeledSpansBinaryRelationsAndLabeledPartitions,
     TextPairDocumentWithLabeledSpansAndBinaryCorefRelations,
 )
 from pie_modules.utils.span import are_nested

--- a/src/pie_modules/document/processing/text_span_trimmer.py
+++ b/src/pie_modules/document/processing/text_span_trimmer.py
@@ -3,10 +3,9 @@ from __future__ import annotations
 import logging
 from typing import TypeVar
 
-from pytorch_ie.annotations import LabeledSpan, Span
 from pytorch_ie.core import AnnotationList, Document
 
-from pie_modules.annotations import LabeledMultiSpan
+from pie_modules.annotations import LabeledMultiSpan, LabeledSpan, Span
 
 logger = logging.getLogger(__name__)
 

--- a/src/pie_modules/document/processing/text_span_trimmer.py
+++ b/src/pie_modules/document/processing/text_span_trimmer.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from typing import TypeVar
 
-from pytorch_ie.core import AnnotationList, Document
+from pytorch_ie.core import AnnotationLayer, Document
 
 from pie_modules.annotations import LabeledMultiSpan, LabeledSpan, Span
 
@@ -38,7 +38,7 @@ def trim_text_spans(
         {k: v for k, v in document.asdict().items() if k not in annotation_layer_names}
     )
 
-    spans: AnnotationList[LabeledSpan] = document[layer]
+    spans: AnnotationLayer[LabeledSpan] = document[layer]
 
     old2new_spans = {}
     removed_span_ids = []

--- a/src/pie_modules/document/processing/tokenization.py
+++ b/src/pie_modules/document/processing/tokenization.py
@@ -17,10 +17,10 @@ from typing import (
 )
 
 from pytorch_ie.core import Annotation
-from pytorch_ie.documents import TextBasedDocument, TokenBasedDocument
 from transformers import PreTrainedTokenizer
 
 from pie_modules.annotations import MultiSpan, Span
+from pie_modules.documents import TextBasedDocument, TokenBasedDocument
 from pie_modules.utils import resolve_type
 
 logger = logging.getLogger(__name__)

--- a/src/pie_modules/documents.py
+++ b/src/pie_modules/documents.py
@@ -1,6 +1,6 @@
 import dataclasses
 
-from pytorch_ie.core import AnnotationLayer, AnnotationList, annotation_field
+from pytorch_ie.core import AnnotationLayer, annotation_field
 
 # re-export all documents from pytorch_ie to have a single entry point
 from pytorch_ie.documents import (
@@ -41,11 +41,11 @@ from pie_modules.annotations import (
 class TextDocumentWithQuestionsAndExtractiveAnswers(TextBasedDocument):
     """A text based PIE document with annotations for extractive question answering."""
 
-    questions: AnnotationList[Question] = annotation_field()
+    questions: AnnotationLayer[Question] = annotation_field()
     # Note: We define the target fields / layers of the answers layer in the following way. Any answer
     # targets the text field and (one entry of) the questions layer, so named_targets needs to contain
     # these *values*. See ExtractiveAnswer.TARGET_NAMES for the required *keys* for named_targets.
-    answers: AnnotationList[ExtractiveAnswer] = annotation_field(
+    answers: AnnotationLayer[ExtractiveAnswer] = annotation_field(
         named_targets={"base": "text", "questions": "questions"}
     )
 
@@ -54,11 +54,11 @@ class TextDocumentWithQuestionsAndExtractiveAnswers(TextBasedDocument):
 class TokenDocumentWithQuestionsAndExtractiveAnswers(TokenBasedDocument):
     """A tokenized PIE document with annotations for extractive question answering."""
 
-    questions: AnnotationList[Question] = annotation_field()
+    questions: AnnotationLayer[Question] = annotation_field()
     # Note: We define the target fields / layers of the answers layer in the following way. Any answer
     # targets the text field and (one entry of) the questions layer, so named_targets needs to contain
     # these *values*. See ExtractiveAnswer.TARGET_NAMES for the required *keys* for named_targets.
-    answers: AnnotationList[ExtractiveAnswer] = annotation_field(
+    answers: AnnotationLayer[ExtractiveAnswer] = annotation_field(
         named_targets={"base": "tokens", "questions": "questions"}
     )
 
@@ -71,12 +71,12 @@ TextDocument = TextBasedDocument
 
 @dataclasses.dataclass
 class TokenDocumentWithLabeledSpans(TokenBasedDocument):
-    labeled_spans: AnnotationList[LabeledSpan] = annotation_field(target="tokens")
+    labeled_spans: AnnotationLayer[LabeledSpan] = annotation_field(target="tokens")
 
 
 @dataclasses.dataclass
 class TokenDocumentWithLabeledPartitions(TokenBasedDocument):
-    labeled_partitions: AnnotationList[LabeledSpan] = annotation_field(target="tokens")
+    labeled_partitions: AnnotationLayer[LabeledSpan] = annotation_field(target="tokens")
 
 
 @dataclasses.dataclass
@@ -88,7 +88,7 @@ class TokenDocumentWithLabeledSpansAndLabeledPartitions(
 
 @dataclasses.dataclass
 class TokenDocumentWithLabeledSpansAndBinaryRelations(TokenDocumentWithLabeledSpans):
-    binary_relations: AnnotationList[BinaryRelation] = annotation_field(target="labeled_spans")
+    binary_relations: AnnotationLayer[BinaryRelation] = annotation_field(target="labeled_spans")
 
 
 @dataclasses.dataclass

--- a/src/pie_modules/documents.py
+++ b/src/pie_modules/documents.py
@@ -66,6 +66,7 @@ class TokenDocumentWithQuestionsAndExtractiveAnswers(TokenBasedDocument):
 # backwards compatibility
 ExtractiveQADocument = TextDocumentWithQuestionsAndExtractiveAnswers
 TokenizedExtractiveQADocument = TokenDocumentWithQuestionsAndExtractiveAnswers
+TextDocument = TextBasedDocument
 
 
 @dataclasses.dataclass

--- a/src/pie_modules/metrics/relation_argument_distance_collector.py
+++ b/src/pie_modules/metrics/relation_argument_distance_collector.py
@@ -1,13 +1,13 @@
 from collections import defaultdict
 from typing import Any, Dict, List, Optional, Type, Union
 
-from pytorch_ie.annotations import BinaryRelation, NaryRelation, Span
 from pytorch_ie.core import Document, DocumentStatistic
-from pytorch_ie.documents import TextBasedDocument, TokenBasedDocument
 from pytorch_ie.utils.hydra import resolve_target
 from transformers import AutoTokenizer, PreTrainedTokenizer
 
+from pie_modules.annotations import BinaryRelation, NaryRelation, Span
 from pie_modules.document.processing import tokenize_document
+from pie_modules.documents import TextBasedDocument, TokenBasedDocument
 from pie_modules.utils.span import distance
 
 

--- a/src/pie_modules/metrics/span_coverage_collector.py
+++ b/src/pie_modules/metrics/span_coverage_collector.py
@@ -1,13 +1,12 @@
 import logging
 from typing import Any, Dict, List, Optional, Set, Type, Union
 
-from pytorch_ie.annotations import Span
 from pytorch_ie.core import Document, DocumentStatistic
-from pytorch_ie.documents import TextBasedDocument, TokenBasedDocument
 from transformers import AutoTokenizer, PreTrainedTokenizer
 
-from pie_modules.annotations import LabeledMultiSpan
+from pie_modules.annotations import LabeledMultiSpan, Span
 from pie_modules.document.processing import tokenize_document
+from pie_modules.documents import TextBasedDocument, TokenBasedDocument
 from pie_modules.utils import resolve_type
 
 logger = logging.getLogger(__name__)

--- a/src/pie_modules/metrics/span_length_collector.py
+++ b/src/pie_modules/metrics/span_length_collector.py
@@ -2,12 +2,12 @@ import logging
 from collections import defaultdict
 from typing import Any, Callable, Dict, List, Optional, Type, Union
 
-from pytorch_ie.annotations import Span
 from pytorch_ie.core import Document, DocumentStatistic
-from pytorch_ie.documents import TextBasedDocument, TokenBasedDocument
 from transformers import AutoTokenizer, PreTrainedTokenizer
 
+from pie_modules.annotations import Span
 from pie_modules.document.processing import tokenize_document
+from pie_modules.documents import TextBasedDocument, TokenBasedDocument
 from pie_modules.utils import resolve_type
 
 logger = logging.getLogger(__name__)

--- a/src/pie_modules/metrics/statistics.py
+++ b/src/pie_modules/metrics/statistics.py
@@ -3,8 +3,9 @@ from collections import defaultdict
 from typing import Any, Callable, Dict, List, Optional, Type, Union
 
 from pytorch_ie.core import Document, DocumentStatistic
-from pytorch_ie.documents import TextBasedDocument
 from transformers import AutoTokenizer, PreTrainedTokenizer
+
+from pie_modules.documents import TextBasedDocument
 
 logger = logging.getLogger(__name__)
 

--- a/src/pie_modules/models/common/has_taskmodule.py
+++ b/src/pie_modules/models/common/has_taskmodule.py
@@ -1,6 +1,7 @@
 from typing import Any, Dict, Optional
 
-from pytorch_ie import AutoTaskModule, TaskModule
+from pytorch_ie.auto import AutoTaskModule
+from pytorch_ie.core import TaskModule
 
 from pie_modules.models.interface import RequiresTaskmoduleConfig
 

--- a/src/pie_modules/models/sequence_classification_with_pooler.py
+++ b/src/pie_modules/models/sequence_classification_with_pooler.py
@@ -14,7 +14,7 @@ from typing import (
 )
 
 import torch
-from pytorch_ie.core import PyTorchIEModel
+from pytorch_ie import PyTorchIEModel
 from pytorch_ie.models.interface import RequiresModelNameOrPath, RequiresNumClasses
 from torch import FloatTensor, LongTensor, nn
 from torch.nn import Parameter

--- a/src/pie_modules/models/simple_extractive_question_answering.py
+++ b/src/pie_modules/models/simple_extractive_question_answering.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, MutableMapping, Optional, Tuple
 
-from pytorch_ie.core import PyTorchIEModel
+from pytorch_ie import PyTorchIEModel
 from pytorch_ie.models.interface import RequiresModelNameOrPath
 from pytorch_lightning.utilities.types import OptimizerLRScheduler
 from torch import Tensor

--- a/src/pie_modules/models/simple_generative.py
+++ b/src/pie_modules/models/simple_generative.py
@@ -3,7 +3,7 @@ import logging
 from typing import Any, Dict, Optional, Tuple, Type, Union
 
 import torch
-from pytorch_ie.core import PyTorchIEModel
+from pytorch_ie import PyTorchIEModel
 from pytorch_lightning.utilities.types import OptimizerLRScheduler
 from torch import FloatTensor, LongTensor
 from torch.optim import Optimizer

--- a/src/pie_modules/models/simple_sequence_classification.py
+++ b/src/pie_modules/models/simple_sequence_classification.py
@@ -2,7 +2,7 @@ import logging
 from typing import Iterator, MutableMapping, Optional, Tuple, Union
 
 import torch.nn
-from pytorch_ie.core import PyTorchIEModel
+from pytorch_ie import PyTorchIEModel
 from pytorch_ie.models.interface import RequiresModelNameOrPath, RequiresNumClasses
 from torch import FloatTensor, LongTensor
 from torch.nn import Parameter

--- a/src/pie_modules/models/simple_token_classification.py
+++ b/src/pie_modules/models/simple_token_classification.py
@@ -2,7 +2,7 @@ import logging
 from typing import MutableMapping, Optional, Tuple, Union
 
 import torch
-from pytorch_ie.core import PyTorchIEModel
+from pytorch_ie import PyTorchIEModel
 from pytorch_ie.models.interface import RequiresModelNameOrPath, RequiresNumClasses
 from pytorch_lightning.utilities.types import OptimizerLRScheduler
 from torch import FloatTensor, LongTensor

--- a/src/pie_modules/models/span_tuple_classification.py
+++ b/src/pie_modules/models/span_tuple_classification.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from typing import Iterator, List, MutableMapping, Optional, Tuple, TypeVar, Union
 
 import torch
-from pytorch_ie.core import PyTorchIEModel
+from pytorch_ie import PyTorchIEModel
 from pytorch_ie.models.interface import RequiresModelNameOrPath, RequiresNumClasses
 from torch import BoolTensor, FloatTensor, LongTensor, Tensor, nn
 from torch.nn import Dropout, Parameter

--- a/src/pie_modules/models/token_classification_with_seq2seq_encoder_and_crf.py
+++ b/src/pie_modules/models/token_classification_with_seq2seq_encoder_and_crf.py
@@ -2,7 +2,7 @@ import logging
 from typing import Any, Dict, MutableMapping, Optional, Tuple, Union
 
 import torch
-from pytorch_ie.core import PyTorchIEModel
+from pytorch_ie import PyTorchIEModel
 from pytorch_ie.models.interface import RequiresModelNameOrPath, RequiresNumClasses
 from pytorch_lightning.utilities.types import OptimizerLRScheduler
 from torch import FloatTensor, LongTensor, nn

--- a/src/pie_modules/taskmodules/common/interfaces.py
+++ b/src/pie_modules/taskmodules/common/interfaces.py
@@ -1,7 +1,7 @@
 import abc
 from typing import Any, Dict, Generic, List, Optional, Tuple, TypeVar
 
-from pytorch_ie import Annotation
+from pytorch_ie.core import Annotation
 
 # Annotation Encoding type: encoding for a single annotation
 AE = TypeVar("AE")

--- a/src/pie_modules/taskmodules/common/mixins.py
+++ b/src/pie_modules/taskmodules/common/mixins.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, Iterable, List, Optional, Tuple
 import pandas as pd
 import torch
 import torch.nn.functional as F
-from pytorch_ie import Annotation
+from pytorch_ie.core import Annotation
 from torch import Tensor
 
 logger = logging.getLogger(__name__)

--- a/src/pie_modules/taskmodules/common/taskmodule_with_document_converter.py
+++ b/src/pie_modules/taskmodules/common/taskmodule_with_document_converter.py
@@ -1,9 +1,10 @@
 from abc import ABC, abstractmethod
 from typing import Generic, Iterable, Iterator, Optional, Sequence, Type, TypeVar, Union
 
-from pytorch_ie import Document, TaskEncoding, TaskModule
+from pytorch_ie.core import Document, TaskModule
 from pytorch_ie.core.taskmodule import (
     IterableTaskEncodingDataset,
+    TaskEncoding,
     TaskEncodingDataset,
     TaskEncodingSequence,
 )

--- a/src/pie_modules/taskmodules/cross_text_binary_coref.py
+++ b/src/pie_modules/taskmodules/cross_text_binary_coref.py
@@ -15,9 +15,7 @@ from typing import (
 )
 
 import torch
-from pytorch_ie import Annotation
-from pytorch_ie.annotations import Span
-from pytorch_ie.core import TaskEncoding, TaskModule
+from pytorch_ie.core import Annotation, TaskEncoding, TaskModule
 from pytorch_ie.utils.window import get_window_around_slice
 from torchmetrics import MetricCollection
 from torchmetrics.classification import (
@@ -28,6 +26,7 @@ from torchmetrics.classification import (
 from transformers import AutoTokenizer, BatchEncoding
 from typing_extensions import TypeAlias
 
+from pie_modules.annotations import Span
 from pie_modules.documents import (
     TextPairDocumentWithLabeledSpansAndBinaryCorefRelations,
 )

--- a/src/pie_modules/taskmodules/extractive_question_answering.py
+++ b/src/pie_modules/taskmodules/extractive_question_answering.py
@@ -5,7 +5,6 @@ from typing import Any, Dict, Iterator, List, Optional, Sequence, Tuple, Union
 import numpy as np
 import torch
 from pytorch_ie.core import Annotation, AnnotationLayer, TaskEncoding, TaskModule
-from pytorch_ie.documents import TextBasedDocument
 from tokenizers import Encoding
 from transformers import AutoTokenizer, BatchEncoding, PreTrainedTokenizer
 from transformers.modeling_outputs import QuestionAnsweringModelOutput
@@ -14,6 +13,7 @@ from typing_extensions import TypeAlias
 from pie_modules.annotations import ExtractiveAnswer, Question
 from pie_modules.document.processing import tokenize_document
 from pie_modules.documents import (
+    TextBasedDocument,
     TextDocumentWithQuestionsAndExtractiveAnswers,
     TokenDocumentWithQuestionsAndExtractiveAnswers,
 )

--- a/src/pie_modules/taskmodules/labeled_span_extraction_by_token_classification.py
+++ b/src/pie_modules/taskmodules/labeled_span_extraction_by_token_classification.py
@@ -24,25 +24,22 @@ from typing import (
 )
 
 import torch
-from pytorch_ie import AnnotationLayer
-from pytorch_ie.annotations import LabeledSpan
-from pytorch_ie.core import TaskEncoding, TaskModule
-from pytorch_ie.documents import (
-    TextDocument,
-    TextDocumentWithLabeledSpans,
-    TextDocumentWithLabeledSpansAndLabeledPartitions,
-)
+from pytorch_ie.core import AnnotationLayer, TaskEncoding, TaskModule
 from pytorch_ie.utils.span import bio_tags_to_spans
 from tokenizers import Encoding
 from torchmetrics import F1Score, Metric, MetricCollection, Precision, Recall
 from transformers import AutoTokenizer
 from typing_extensions import TypeAlias
 
+from pie_modules.annotations import LabeledSpan
 from pie_modules.document.processing import (
     token_based_document_to_text_based,
     tokenize_document,
 )
 from pie_modules.documents import (
+    TextBasedDocument,
+    TextDocumentWithLabeledSpans,
+    TextDocumentWithLabeledSpansAndLabeledPartitions,
     TokenDocumentWithLabeledSpans,
     TokenDocumentWithLabeledSpansAndLabeledPartitions,
 )
@@ -54,7 +51,7 @@ from pie_modules.taskmodules.metrics import (
 )
 from pie_modules.utils import list_of_dicts2dict_of_lists
 
-DocumentType: TypeAlias = TextDocument
+DocumentType: TypeAlias = TextBasedDocument
 
 InputEncodingType: TypeAlias = Encoding
 TargetEncodingType: TypeAlias = Sequence[int]
@@ -181,8 +178,8 @@ class LabeledSpanExtractionByTokenClassificationTaskModule(TaskModuleType):
         self.tokenizer = AutoTokenizer.from_pretrained(tokenizer_name_or_path)
 
     @property
-    def document_type(self) -> Optional[Type[TextDocument]]:
-        dt: Type[TextDocument]
+    def document_type(self) -> Optional[Type[TextBasedDocument]]:
+        dt: Type[TextBasedDocument]
         errors = []
         if self.span_annotation != "labeled_spans":
             errors.append(
@@ -236,7 +233,7 @@ class LabeledSpanExtractionByTokenClassificationTaskModule(TaskModuleType):
 
     def encode_input(
         self,
-        document: TextDocument,
+        document: TextBasedDocument,
     ) -> Optional[Union[TaskEncodingType, Sequence[TaskEncodingType]]]:
         if self.partition_annotation is None:
             tokenized_document_type = TokenDocumentWithLabeledSpans

--- a/src/pie_modules/taskmodules/metrics/precision_recall_and_f1_for_labeled_annotations.py
+++ b/src/pie_modules/taskmodules/metrics/precision_recall_and_f1_for_labeled_annotations.py
@@ -3,7 +3,7 @@ from collections import Counter
 from typing import Any, Collection, Dict, Iterable, Optional, Union
 
 import torch
-from pytorch_ie import Annotation
+from pytorch_ie.core import Annotation
 from torch import LongTensor
 
 from pie_modules.utils import flatten_dict

--- a/src/pie_modules/taskmodules/pointer_network/annotation_encoder_decoder.py
+++ b/src/pie_modules/taskmodules/pointer_network/annotation_encoder_decoder.py
@@ -2,8 +2,7 @@ import logging
 from collections import defaultdict
 from typing import Any, Dict, List, Optional, Set, Tuple
 
-from pytorch_ie.annotations import BinaryRelation, LabeledSpan, Span
-
+from pie_modules.annotations import BinaryRelation, LabeledSpan, Span
 from pie_modules.taskmodules.common import AnnotationEncoderDecoder, DecodingException
 
 logger = logging.getLogger(__name__)

--- a/src/pie_modules/taskmodules/pointer_network_for_end2end_re.py
+++ b/src/pie_modules/taskmodules/pointer_network_for_end2end_re.py
@@ -18,22 +18,29 @@ from typing import (
 )
 
 import torch
-from pytorch_ie import AnnotationLayer, Document
-from pytorch_ie.annotations import BinaryRelation, LabeledSpan
-from pytorch_ie.core import Annotation, TaskEncoding, TaskModule
+from pytorch_ie.core import (
+    Annotation,
+    AnnotationLayer,
+    Document,
+    TaskModule,
+)
 from pytorch_ie.core.taskmodule import (
     InputEncoding,
     ModelBatchOutput,
     TargetEncoding,
     TaskBatchEncoding,
+    TaskEncoding,
 )
-from pytorch_ie.documents import TextBasedDocument, TokenBasedDocument
 from torchmetrics import Metric
 from transformers import AutoTokenizer, LogitsProcessorList, PreTrainedTokenizer
 from typing_extensions import TypeAlias
 
+from pie_modules.annotations import BinaryRelation, LabeledSpan
+
 # import for backwards compatibility (don't remove!)
 from pie_modules.documents import (
+    TextBasedDocument,
+    TokenBasedDocument,
     TokenDocumentWithLabeledSpansBinaryRelationsAndLabeledPartitions,
 )
 

--- a/src/pie_modules/taskmodules/re_span_pair_classification.py
+++ b/src/pie_modules/taskmodules/re_span_pair_classification.py
@@ -29,7 +29,7 @@ import pandas as pd
 import torch
 from pytorch_ie.core import (
     Annotation,
-    AnnotationList,
+    AnnotationLayer,
     Document,
     TaskEncoding,
     TaskModule,
@@ -349,22 +349,22 @@ class RESpanPairClassificationTaskModule(TaskModuleType, ChangesTokenizerVocabSi
         )
         return casted_document
 
-    def get_relation_layer(self, document: Document) -> AnnotationList[BinaryRelation]:
+    def get_relation_layer(self, document: Document) -> AnnotationLayer[BinaryRelation]:
         return document[self.relation_annotation]
 
     def get_span_layer_name(self, document: Document) -> str:
         return document[self.relation_annotation].target_name
 
-    def get_entity_layer(self, document: Document) -> AnnotationList[LabeledSpan]:
-        relations: AnnotationList[BinaryRelation] = self.get_relation_layer(document)
+    def get_entity_layer(self, document: Document) -> AnnotationLayer[LabeledSpan]:
+        relations: AnnotationLayer[BinaryRelation] = self.get_relation_layer(document)
         return relations.target_layer
 
     def _prepare(self, documents: Sequence[DocumentType]) -> None:
         entity_labels: Set[str] = set()
         relation_labels: Set[str] = set()
         for document in documents:
-            relations: AnnotationList[BinaryRelation] = self.get_relation_layer(document)
-            entities: AnnotationList[LabeledSpan] = self.get_entity_layer(document)
+            relations: AnnotationLayer[BinaryRelation] = self.get_relation_layer(document)
+            entities: AnnotationLayer[LabeledSpan] = self.get_entity_layer(document)
 
             for entity in entities:
                 entity_labels.add(entity.label)

--- a/src/pie_modules/taskmodules/re_span_pair_classification.py
+++ b/src/pie_modules/taskmodules/re_span_pair_classification.py
@@ -27,24 +27,12 @@ from typing import (
 
 import pandas as pd
 import torch
-from pytorch_ie.annotations import (
-    BinaryRelation,
-    LabeledSpan,
-    MultiLabeledBinaryRelation,
-    NaryRelation,
-)
 from pytorch_ie.core import (
     Annotation,
     AnnotationList,
     Document,
     TaskEncoding,
     TaskModule,
-)
-from pytorch_ie.documents import (
-    TextDocument,
-    TextDocumentWithLabeledPartitions,
-    TextDocumentWithLabeledSpansAndBinaryRelations,
-    TextDocumentWithLabeledSpansBinaryRelationsAndLabeledPartitions,
 )
 from pytorch_ie.taskmodules.interface import ChangesTokenizerVocabSize
 from tokenizers import AddedToken
@@ -54,11 +42,21 @@ from torchmetrics import ClasswiseWrapper, F1Score, Metric, MetricCollection
 from transformers import AutoTokenizer
 from typing_extensions import TypeAlias
 
+from pie_modules.annotations import (
+    BinaryRelation,
+    LabeledSpan,
+    MultiLabeledBinaryRelation,
+    NaryRelation,
+)
 from pie_modules.document.processing import (
     token_based_document_to_text_based,
     tokenize_document,
 )
 from pie_modules.documents import (
+    TextBasedDocument,
+    TextDocumentWithLabeledPartitions,
+    TextDocumentWithLabeledSpansAndBinaryRelations,
+    TextDocumentWithLabeledSpansBinaryRelationsAndLabeledPartitions,
     TokenDocumentWithLabeledSpansAndBinaryRelations,
     TokenDocumentWithLabeledSpansBinaryRelationsAndLabeledPartitions,
 )
@@ -105,7 +103,7 @@ class TargetEncodingType(TypedDict, total=False):
     labels: LongTensor
 
 
-DocumentType: TypeAlias = TextDocument
+DocumentType: TypeAlias = TextBasedDocument
 TaskEncodingType: TypeAlias = TaskEncoding[
     DocumentType,
     InputEncodingType,

--- a/src/pie_modules/taskmodules/re_text_classification_with_indices.py
+++ b/src/pie_modules/taskmodules/re_text_classification_with_indices.py
@@ -29,7 +29,7 @@ import numpy as np
 import torch
 from pytorch_ie.core import (
     Annotation,
-    AnnotationList,
+    AnnotationLayer,
     Document,
     TaskEncoding,
     TaskModule,
@@ -503,11 +503,11 @@ class RETextClassificationWithIndicesTaskModule(
             )
             return None
 
-    def get_relation_layer(self, document: Document) -> AnnotationList[BinaryRelation]:
+    def get_relation_layer(self, document: Document) -> AnnotationLayer[BinaryRelation]:
         return document[self.relation_annotation]
 
-    def get_entity_layer(self, document: Document) -> AnnotationList[LabeledSpan]:
-        relations: AnnotationList[BinaryRelation] = self.get_relation_layer(document)
+    def get_entity_layer(self, document: Document) -> AnnotationLayer[LabeledSpan]:
+        relations: AnnotationLayer[BinaryRelation] = self.get_relation_layer(document)
         return relations.target_layer
 
     def get_marker_factory(self) -> MarkerFactory:
@@ -517,8 +517,8 @@ class RETextClassificationWithIndicesTaskModule(
         entity_labels: Set[str] = set()
         relation_labels: Set[str] = set()
         for document in documents:
-            relations: AnnotationList[BinaryRelation] = self.get_relation_layer(document)
-            entities: AnnotationList[LabeledSpan] = self.get_entity_layer(document)
+            relations: AnnotationLayer[BinaryRelation] = self.get_relation_layer(document)
+            entities: AnnotationLayer[LabeledSpan] = self.get_entity_layer(document)
 
             for entity in entities:
                 entity_labels.add(entity.label)

--- a/src/pie_modules/taskmodules/re_text_classification_with_indices.py
+++ b/src/pie_modules/taskmodules/re_text_classification_with_indices.py
@@ -27,24 +27,12 @@ from typing import (
 
 import numpy as np
 import torch
-from pytorch_ie.annotations import (
-    BinaryRelation,
-    LabeledSpan,
-    MultiLabeledBinaryRelation,
-    NaryRelation,
-    Span,
-)
 from pytorch_ie.core import (
     Annotation,
     AnnotationList,
     Document,
     TaskEncoding,
     TaskModule,
-)
-from pytorch_ie.documents import (
-    TextDocument,
-    TextDocumentWithLabeledSpansAndBinaryRelations,
-    TextDocumentWithLabeledSpansBinaryRelationsAndLabeledPartitions,
 )
 from pytorch_ie.taskmodules.interface import ChangesTokenizerVocabSize
 from pytorch_ie.utils.span import has_overlap, is_contained_in
@@ -56,6 +44,18 @@ from transformers.file_utils import PaddingStrategy
 from transformers.tokenization_utils_base import TruncationStrategy
 from typing_extensions import TypeAlias, TypeVar
 
+from pie_modules.annotations import (
+    BinaryRelation,
+    LabeledSpan,
+    MultiLabeledBinaryRelation,
+    NaryRelation,
+    Span,
+)
+from pie_modules.documents import (
+    TextBasedDocument,
+    TextDocumentWithLabeledSpansAndBinaryRelations,
+    TextDocumentWithLabeledSpansBinaryRelationsAndLabeledPartitions,
+)
 from pie_modules.models.simple_sequence_classification import (
     InputType as ModelInputType,
 )
@@ -71,7 +71,7 @@ from pie_modules.utils.tokenization import (
 
 InputEncodingType: TypeAlias = Dict[str, Any]
 TargetEncodingType: TypeAlias = Sequence[int]
-DocumentType: TypeAlias = TextDocument
+DocumentType: TypeAlias = TextBasedDocument
 
 TaskEncodingType: TypeAlias = TaskEncoding[
     DocumentType,

--- a/src/pie_modules/taskmodules/text_to_text.py
+++ b/src/pie_modules/taskmodules/text_to_text.py
@@ -15,15 +15,19 @@ from typing import (
 )
 
 import torch
-from pytorch_ie import AnnotationLayer, Document
-from pytorch_ie.core import Annotation, TaskEncoding, TaskModule
+from pytorch_ie.core import (
+    Annotation,
+    AnnotationLayer,
+    Document,
+    TaskModule,
+)
 from pytorch_ie.core.taskmodule import (
     InputEncoding,
     ModelBatchOutput,
     TargetEncoding,
     TaskBatchEncoding,
+    TaskEncoding,
 )
-from pytorch_ie.documents import TextBasedDocument, TokenBasedDocument
 from torchmetrics import Metric
 from transformers import AutoTokenizer, PreTrainedTokenizer
 from typing_extensions import TypeAlias
@@ -33,6 +37,7 @@ from pie_modules.document.processing import (
     token_based_document_to_text_based,
     tokenize_document,
 )
+from pie_modules.documents import TextBasedDocument, TokenBasedDocument
 from pie_modules.utils import resolve_type
 
 from .common import BatchableMixin, get_first_occurrence_index

--- a/src/pie_modules/utils/hydra.py
+++ b/src/pie_modules/utils/hydra.py
@@ -1,6 +1,6 @@
 from typing import Optional, Type, TypeVar, Union
 
-from pytorch_ie import Document
+from pytorch_ie.core import Document
 from pytorch_ie.utils.hydra import resolve_target
 
 T = TypeVar("T", bound=Document)

--- a/src/pie_modules/utils/tokenization.py
+++ b/src/pie_modules/utils/tokenization.py
@@ -1,7 +1,8 @@
 from typing import TypeVar
 
-from pytorch_ie.annotations import Span
 from transformers import BatchEncoding
+
+from pie_modules.annotations import Span
 
 S = TypeVar("S", bound=Span)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,10 +3,10 @@ import json
 
 import pkg_resources
 import pytest
-from pytorch_ie.annotations import BinaryRelation, LabeledSpan, Span
 from pytorch_ie.core import AnnotationList, annotation_field
-from pytorch_ie.documents import TextBasedDocument
 
+from pie_modules.annotations import BinaryRelation, LabeledSpan, Span
+from pie_modules.documents import TextBasedDocument
 from tests import DUMP_FIXTURE_DATA, FIXTURES_ROOT
 
 _TABULATE_AVAILABLE = "tabulate" in {pkg.key for pkg in pkg_resources.working_set}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@ import json
 
 import pkg_resources
 import pytest
-from pytorch_ie.core import AnnotationList, annotation_field
+from pytorch_ie.core import AnnotationLayer, annotation_field
 
 from pie_modules.annotations import BinaryRelation, LabeledSpan, Span
 from pie_modules.documents import TextBasedDocument
@@ -14,9 +14,9 @@ _TABULATE_AVAILABLE = "tabulate" in {pkg.key for pkg in pkg_resources.working_se
 
 @dataclasses.dataclass
 class TestDocument(TextBasedDocument):
-    sentences: AnnotationList[Span] = annotation_field(target="text")
-    entities: AnnotationList[LabeledSpan] = annotation_field(target="text")
-    relations: AnnotationList[BinaryRelation] = annotation_field(target="entities")
+    sentences: AnnotationLayer[Span] = annotation_field(target="text")
+    entities: AnnotationLayer[LabeledSpan] = annotation_field(target="text")
+    relations: AnnotationLayer[BinaryRelation] = annotation_field(target="entities")
 
 
 def example_to_doc_dict(example):

--- a/tests/document/processing/test_merge_spans_via_relation.py
+++ b/tests/document/processing/test_merge_spans_via_relation.py
@@ -1,7 +1,4 @@
 import pytest
-from pytorch_ie.documents import (
-    TextDocumentWithLabeledSpansBinaryRelationsAndLabeledPartitions,
-)
 
 from pie_modules.annotations import BinaryRelation, LabeledMultiSpan, LabeledSpan
 from pie_modules.document.processing import SpansViaRelationMerger
@@ -12,6 +9,7 @@ from pie_modules.documents import (
     TextDocumentWithLabeledMultiSpansAndBinaryRelations,
     TextDocumentWithLabeledMultiSpansBinaryRelationsAndLabeledPartitions,
     TextDocumentWithLabeledSpansAndBinaryRelations,
+    TextDocumentWithLabeledSpansBinaryRelationsAndLabeledPartitions,
 )
 
 

--- a/tests/document/processing/test_regex_partitioner.py
+++ b/tests/document/processing/test_regex_partitioner.py
@@ -4,7 +4,7 @@ import logging
 from typing import Tuple
 
 import pytest
-from pytorch_ie.core import AnnotationList, annotation_field
+from pytorch_ie.core import AnnotationLayer, annotation_field
 
 from pie_modules.annotations import LabeledSpan
 from pie_modules.document.processing import RegexPartitioner
@@ -16,7 +16,7 @@ from pie_modules.documents import TextBasedDocument
 
 @dataclasses.dataclass
 class TextDocumentWithPartitions(TextBasedDocument):
-    partitions: AnnotationList[LabeledSpan] = annotation_field(target="text")
+    partitions: AnnotationLayer[LabeledSpan] = annotation_field(target="text")
 
 
 def have_overlap(start_end: Tuple[int, int], other_start_end: Tuple[int, int]) -> bool:

--- a/tests/document/processing/test_regex_partitioner.py
+++ b/tests/document/processing/test_regex_partitioner.py
@@ -4,14 +4,14 @@ import logging
 from typing import Tuple
 
 import pytest
-from pytorch_ie.annotations import LabeledSpan
 from pytorch_ie.core import AnnotationList, annotation_field
-from pytorch_ie.documents import TextBasedDocument
 
+from pie_modules.annotations import LabeledSpan
 from pie_modules.document.processing import RegexPartitioner
 from pie_modules.document.processing.regex_partitioner import (
     _get_partitions_with_matcher,
 )
+from pie_modules.documents import TextBasedDocument
 
 
 @dataclasses.dataclass

--- a/tests/document/processing/test_relation_argument_sorter.py
+++ b/tests/document/processing/test_relation_argument_sorter.py
@@ -2,19 +2,23 @@ import dataclasses
 import logging
 
 import pytest
-from pytorch_ie import Annotation, AnnotationLayer, annotation_field
-from pytorch_ie.annotations import BinaryRelation, LabeledSpan, NaryRelation
-from pytorch_ie.documents import (
-    TextBasedDocument,
-    TextDocumentWithLabeledSpans,
-    TextDocumentWithLabeledSpansAndBinaryRelations,
-)
+from pytorch_ie.core import Annotation, AnnotationLayer, annotation_field
 
-from pie_modules.annotations import LabeledMultiSpan
+from pie_modules.annotations import (
+    BinaryRelation,
+    LabeledMultiSpan,
+    LabeledSpan,
+    NaryRelation,
+)
 from pie_modules.document.processing import RelationArgumentSorter
 from pie_modules.document.processing.relation_argument_sorter import (
     construct_relation_with_new_args,
     get_relation_args,
+)
+from pie_modules.documents import (
+    TextBasedDocument,
+    TextDocumentWithLabeledSpans,
+    TextDocumentWithLabeledSpansAndBinaryRelations,
 )
 
 

--- a/tests/document/processing/test_sentence_splitter.py
+++ b/tests/document/processing/test_sentence_splitter.py
@@ -1,11 +1,11 @@
 import pytest
-from pytorch_ie.annotations import LabeledSpan
-from pytorch_ie.documents import TextDocumentWithLabeledPartitions
 
+from pie_modules.annotations import LabeledSpan
 from pie_modules.document.processing import (
     FlairSegtokSentenceSplitter,
     NltkSentenceSplitter,
 )
+from pie_modules.documents import TextDocumentWithLabeledPartitions
 
 
 @pytest.mark.parametrize("inplace", [True, False])

--- a/tests/document/processing/test_text_pair.py
+++ b/tests/document/processing/test_text_pair.py
@@ -2,11 +2,8 @@ import random
 from typing import List
 
 import pytest
-from pytorch_ie.annotations import BinaryRelation, LabeledSpan
-from pytorch_ie.documents import (
-    TextDocumentWithLabeledSpansBinaryRelationsAndLabeledPartitions,
-)
 
+from pie_modules.annotations import BinaryRelation, LabeledSpan
 from pie_modules.document.processing.text_pair import (
     add_negative_coref_relations,
     construct_text_document_from_text_pair_coref_document,
@@ -14,6 +11,7 @@ from pie_modules.document.processing.text_pair import (
 )
 from pie_modules.documents import (
     BinaryCorefRelation,
+    TextDocumentWithLabeledSpansBinaryRelationsAndLabeledPartitions,
     TextPairDocumentWithLabeledSpansAndBinaryCorefRelations,
 )
 

--- a/tests/document/processing/test_text_span_trimmer.py
+++ b/tests/document/processing/test_text_span_trimmer.py
@@ -1,12 +1,11 @@
 import dataclasses
 
 import pytest
-from pytorch_ie.annotations import BinaryRelation, LabeledSpan
 from pytorch_ie.core import AnnotationList, annotation_field
-from pytorch_ie.documents import TextBasedDocument
 
-from pie_modules.annotations import LabeledMultiSpan
+from pie_modules.annotations import BinaryRelation, LabeledMultiSpan, LabeledSpan
 from pie_modules.document.processing import TextSpanTrimmer
+from pie_modules.documents import TextBasedDocument
 
 
 @dataclasses.dataclass

--- a/tests/document/processing/test_text_span_trimmer.py
+++ b/tests/document/processing/test_text_span_trimmer.py
@@ -1,7 +1,7 @@
 import dataclasses
 
 import pytest
-from pytorch_ie.core import AnnotationList, annotation_field
+from pytorch_ie.core import AnnotationLayer, annotation_field
 
 from pie_modules.annotations import BinaryRelation, LabeledMultiSpan, LabeledSpan
 from pie_modules.document.processing import TextSpanTrimmer
@@ -10,9 +10,9 @@ from pie_modules.documents import TextBasedDocument
 
 @dataclasses.dataclass
 class DocumentWithEntitiesRelationsAndPartitions(TextBasedDocument):
-    entities: AnnotationList[LabeledSpan] = annotation_field(target="text")
-    relations: AnnotationList[BinaryRelation] = annotation_field(target="entities")
-    partitions: AnnotationList[LabeledSpan] = annotation_field(target="text")
+    entities: AnnotationLayer[LabeledSpan] = annotation_field(target="text")
+    relations: AnnotationLayer[BinaryRelation] = annotation_field(target="entities")
+    partitions: AnnotationLayer[LabeledSpan] = annotation_field(target="text")
 
 
 @pytest.fixture
@@ -121,8 +121,8 @@ def test_text_span_trimmer_remove_entity_of_relations(document1):
 
 @dataclasses.dataclass
 class DocumentWithLabeledMultiSpansAndBinaryRelations(TextBasedDocument):
-    labeled_multi_spans: AnnotationList[LabeledMultiSpan] = annotation_field(target="text")
-    binary_relations: AnnotationList[BinaryRelation] = annotation_field(
+    labeled_multi_spans: AnnotationLayer[LabeledMultiSpan] = annotation_field(target="text")
+    binary_relations: AnnotationLayer[BinaryRelation] = annotation_field(
         target="labeled_multi_spans"
     )
 

--- a/tests/document/processing/test_tokenization.py
+++ b/tests/document/processing/test_tokenization.py
@@ -3,7 +3,7 @@ from collections import defaultdict
 from typing import Dict
 
 import pytest
-from pytorch_ie.core import Annotation, AnnotationList, Document, annotation_field
+from pytorch_ie.core import Annotation, AnnotationLayer, Document, annotation_field
 from transformers import AutoTokenizer, PreTrainedTokenizer
 
 from pie_modules.annotations import (
@@ -25,21 +25,21 @@ from tests.conftest import TestDocument
 
 @dataclasses.dataclass
 class TokenizedTestDocument(TokenBasedDocument):
-    sentences: AnnotationList[Span] = annotation_field(target="tokens")
-    entities: AnnotationList[LabeledSpan] = annotation_field(target="tokens")
-    relations: AnnotationList[BinaryRelation] = annotation_field(target="entities")
+    sentences: AnnotationLayer[Span] = annotation_field(target="tokens")
+    entities: AnnotationLayer[LabeledSpan] = annotation_field(target="tokens")
+    relations: AnnotationLayer[BinaryRelation] = annotation_field(target="entities")
 
 
 @dataclasses.dataclass
 class TestDocumentWithMultiSpans(TextBasedDocument):
-    entities: AnnotationList[LabeledMultiSpan] = annotation_field(target="text")
-    relations: AnnotationList[BinaryRelation] = annotation_field(target="entities")
+    entities: AnnotationLayer[LabeledMultiSpan] = annotation_field(target="text")
+    relations: AnnotationLayer[BinaryRelation] = annotation_field(target="entities")
 
 
 @dataclasses.dataclass
 class TokenizedTestDocumentWithMultiSpans(TokenBasedDocument):
-    entities: AnnotationList[LabeledMultiSpan] = annotation_field(target="tokens")
-    relations: AnnotationList[BinaryRelation] = annotation_field(target="entities")
+    entities: AnnotationLayer[LabeledMultiSpan] = annotation_field(target="tokens")
+    relations: AnnotationLayer[BinaryRelation] = annotation_field(target="entities")
 
 
 @pytest.fixture
@@ -545,7 +545,7 @@ def test_token_based_document_to_text_based_strip_multi_span(
 def test_text_based_document_to_token_based_wrong_annotation_type():
     @dataclasses.dataclass
     class WrongAnnotationType(TextBasedDocument):
-        wrong_annotations: AnnotationList[Label] = annotation_field(target="text")
+        wrong_annotations: AnnotationLayer[Label] = annotation_field(target="text")
 
     doc = WrongAnnotationType(text="First sentence. Entity M works at N. And it founded O.")
     doc.wrong_annotations.append(Label(label="wrong"))
@@ -636,7 +636,7 @@ def test_token_based_document_token_based_offset_mapping_from_metadata(
 def test_token_based_document_to_text_based_wrong_annotation_type():
     @dataclasses.dataclass
     class WrongAnnotationType(TokenBasedDocument):
-        wrong_annotations: AnnotationList[Label] = annotation_field(target="tokens")
+        wrong_annotations: AnnotationLayer[Label] = annotation_field(target="tokens")
 
     doc = WrongAnnotationType(tokens=("Hallo", "World"))
     doc.wrong_annotations.append(Label(label="wrong"))

--- a/tests/document/processing/test_tokenization.py
+++ b/tests/document/processing/test_tokenization.py
@@ -3,9 +3,7 @@ from collections import defaultdict
 from typing import Dict
 
 import pytest
-from pytorch_ie import Annotation, Document
-from pytorch_ie.core import AnnotationList, annotation_field
-from pytorch_ie.documents import TextBasedDocument, TokenBasedDocument
+from pytorch_ie.core import Annotation, AnnotationList, Document, annotation_field
 from transformers import AutoTokenizer, PreTrainedTokenizer
 
 from pie_modules.annotations import (
@@ -21,6 +19,7 @@ from pie_modules.document.processing import (
     tokenize_document,
 )
 from pie_modules.document.processing.tokenization import find_token_offset_mapping
+from pie_modules.documents import TextBasedDocument, TokenBasedDocument
 from tests.conftest import TestDocument
 
 

--- a/tests/metrics/test_confusion_matrix.py
+++ b/tests/metrics/test_confusion_matrix.py
@@ -4,10 +4,10 @@ from functools import partial
 from typing import Dict
 
 import pytest
-from pytorch_ie.annotations import LabeledSpan
 from pytorch_ie.core import Annotation, AnnotationLayer, annotation_field
-from pytorch_ie.documents import TextBasedDocument
 
+from pie_modules.annotations import LabeledSpan
+from pie_modules.documents import TextBasedDocument
 from pie_modules.metrics import ConfusionMatrix
 
 

--- a/tests/metrics/test_f1.py
+++ b/tests/metrics/test_f1.py
@@ -1,10 +1,10 @@
 from dataclasses import dataclass
 
 import pytest
-from pytorch_ie.annotations import LabeledSpan
 from pytorch_ie.core import AnnotationLayer, annotation_field
-from pytorch_ie.documents import TextBasedDocument
 
+from pie_modules.annotations import LabeledSpan
+from pie_modules.documents import TextBasedDocument
 from pie_modules.metrics import F1Metric
 
 

--- a/tests/metrics/test_relation_argument_distance_collector.py
+++ b/tests/metrics/test_relation_argument_distance_collector.py
@@ -1,11 +1,10 @@
 import dataclasses
 
 import pytest
-from pytorch_ie import Annotation, Document
-from pytorch_ie.annotations import BinaryRelation, LabeledSpan, NaryRelation
-from pytorch_ie.core import AnnotationList, annotation_field
-from pytorch_ie.documents import TextBasedDocument, TokenBasedDocument
+from pytorch_ie.core import Annotation, AnnotationList, Document, annotation_field
 
+from pie_modules.annotations import BinaryRelation, LabeledSpan, NaryRelation
+from pie_modules.documents import TextBasedDocument, TokenBasedDocument
 from pie_modules.metrics import RelationArgumentDistanceCollector
 
 

--- a/tests/metrics/test_relation_argument_distance_collector.py
+++ b/tests/metrics/test_relation_argument_distance_collector.py
@@ -1,7 +1,7 @@
 import dataclasses
 
 import pytest
-from pytorch_ie.core import Annotation, AnnotationList, Document, annotation_field
+from pytorch_ie.core import Annotation, AnnotationLayer, Document, annotation_field
 
 from pie_modules.annotations import BinaryRelation, LabeledSpan, NaryRelation
 from pie_modules.documents import TextBasedDocument, TokenBasedDocument
@@ -10,8 +10,8 @@ from pie_modules.metrics import RelationArgumentDistanceCollector
 
 @dataclasses.dataclass
 class TestDocument(TextBasedDocument):
-    entities: AnnotationList[LabeledSpan] = annotation_field(target="text")
-    relations: AnnotationList[BinaryRelation] = annotation_field(target="entities")
+    entities: AnnotationLayer[LabeledSpan] = annotation_field(target="text")
+    relations: AnnotationLayer[BinaryRelation] = annotation_field(target="entities")
 
 
 def test_relation_argument_distance_collector():
@@ -99,8 +99,8 @@ def test_relation_argument_distance_collector_with_tokenize():
 
     @dataclasses.dataclass
     class TokenizedTestDocument(TokenBasedDocument):
-        entities: AnnotationList[LabeledSpan] = annotation_field(target="tokens")
-        relations: AnnotationList[BinaryRelation] = annotation_field(target="entities")
+        entities: AnnotationLayer[LabeledSpan] = annotation_field(target="tokens")
+        relations: AnnotationLayer[BinaryRelation] = annotation_field(target="entities")
 
     statistic = RelationArgumentDistanceCollector(
         layer="relations",
@@ -145,8 +145,8 @@ def test_relation_argument_distance_collector_with_tokenize_wrong_document_type(
     @dataclasses.dataclass
     class TestDocument(Document):
         data: str
-        entities: AnnotationList[LabeledSpan] = annotation_field(target="data")
-        relations: AnnotationList[BinaryRelation] = annotation_field(target="entities")
+        entities: AnnotationLayer[LabeledSpan] = annotation_field(target="data")
+        relations: AnnotationLayer[BinaryRelation] = annotation_field(target="entities")
 
     doc = TestDocument(
         data="This is the first entity. This is the second entity. This is the third entity."
@@ -164,8 +164,8 @@ def test_relation_argument_distance_collector_with_tokenize_wrong_document_type(
 
     @dataclasses.dataclass
     class TokenizedTestDocument(TokenBasedDocument):
-        entities: AnnotationList[LabeledSpan] = annotation_field(target="tokens")
-        relations: AnnotationList[BinaryRelation] = annotation_field(target="entities")
+        entities: AnnotationLayer[LabeledSpan] = annotation_field(target="tokens")
+        relations: AnnotationLayer[BinaryRelation] = annotation_field(target="entities")
 
     statistic = RelationArgumentDistanceCollector(
         layer="relations",
@@ -190,8 +190,8 @@ def test_relation_argument_distance_collector_with_tokenize_wrong_span_annotatio
 
     @dataclasses.dataclass
     class TestDocument(TextBasedDocument):
-        labeled_multi_spans: AnnotationList[UnknownSpan] = annotation_field(target="text")
-        binary_relations: AnnotationList[BinaryRelation] = annotation_field(
+        labeled_multi_spans: AnnotationLayer[UnknownSpan] = annotation_field(target="text")
+        binary_relations: AnnotationLayer[BinaryRelation] = annotation_field(
             target="labeled_multi_spans"
         )
 
@@ -224,8 +224,8 @@ def test_relation_argument_distance_collector_with_tokenize_wrong_relation_annot
 
     @dataclasses.dataclass
     class TestDocument(TextBasedDocument):
-        labeled_spans: AnnotationList[LabeledSpan] = annotation_field(target="text")
-        not_binary_relations: AnnotationList[UnknownRelation] = annotation_field(
+        labeled_spans: AnnotationLayer[LabeledSpan] = annotation_field(target="text")
+        not_binary_relations: AnnotationLayer[UnknownRelation] = annotation_field(
             target="labeled_spans"
         )
 

--- a/tests/metrics/test_span_coverage_collector.py
+++ b/tests/metrics/test_span_coverage_collector.py
@@ -1,7 +1,7 @@
 import dataclasses
 
 import pytest
-from pytorch_ie.core import Annotation, AnnotationList, Document, annotation_field
+from pytorch_ie.core import Annotation, AnnotationLayer, Document, annotation_field
 
 from pie_modules.annotations import LabeledMultiSpan, LabeledSpan
 from pie_modules.documents import TextBasedDocument, TokenBasedDocument
@@ -10,7 +10,7 @@ from pie_modules.metrics import SpanCoverageCollector
 
 @dataclasses.dataclass
 class TestDocument(TextBasedDocument):
-    entities: AnnotationList[LabeledSpan] = annotation_field(target="text")
+    entities: AnnotationLayer[LabeledSpan] = annotation_field(target="text")
 
 
 def test_span_coverage_collector():
@@ -26,7 +26,7 @@ def test_span_coverage_collector():
 def test_span_coverage_collector_with_multi_span():
     @dataclasses.dataclass
     class TestDocument(TextBasedDocument):
-        entities: AnnotationList[LabeledMultiSpan] = annotation_field(target="text")
+        entities: AnnotationLayer[LabeledMultiSpan] = annotation_field(target="text")
 
     doc = TestDocument(text="A and O.")
     doc.entities.append(LabeledMultiSpan(slices=((0, 1),), label="entity"))
@@ -60,7 +60,7 @@ def test_span_coverage_collector_with_tokenize():
 
     @dataclasses.dataclass
     class TokenizedTestDocument(TokenBasedDocument):
-        entities: AnnotationList[LabeledSpan] = annotation_field(target="tokens")
+        entities: AnnotationLayer[LabeledSpan] = annotation_field(target="tokens")
 
     statistic = SpanCoverageCollector(
         layer="entities",
@@ -108,13 +108,13 @@ def test_span_coverage_collector_with_tokenize_wrong_document_type():
     @dataclasses.dataclass
     class TestDocument(Document):
         data: str
-        entities: AnnotationList[LabeledSpan] = annotation_field(target="data")
+        entities: AnnotationLayer[LabeledSpan] = annotation_field(target="data")
 
     doc = TestDocument(data="A and O")
 
     @dataclasses.dataclass
     class TokenizedTestDocument(TokenBasedDocument):
-        entities: AnnotationList[LabeledSpan] = annotation_field(target="tokens")
+        entities: AnnotationLayer[LabeledSpan] = annotation_field(target="tokens")
 
     statistic = SpanCoverageCollector(
         layer="entities",
@@ -139,7 +139,7 @@ def test_span_coverage_collector_with_tokenize_wrong_annotation_type():
 
     @dataclasses.dataclass
     class TestDocument(TextBasedDocument):
-        labeled_multi_spans: AnnotationList[UnknownSpan] = annotation_field(target="text")
+        labeled_multi_spans: AnnotationLayer[UnknownSpan] = annotation_field(target="text")
 
     doc = TestDocument(text="First sentence. Entity M works at N. And it founded O.")
     doc.labeled_multi_spans.append(UnknownSpan(start=16, end=24))

--- a/tests/metrics/test_span_coverage_collector.py
+++ b/tests/metrics/test_span_coverage_collector.py
@@ -1,12 +1,10 @@
 import dataclasses
 
 import pytest
-from pytorch_ie import Annotation, Document
-from pytorch_ie.annotations import LabeledSpan
-from pytorch_ie.core import AnnotationList, annotation_field
-from pytorch_ie.documents import TextBasedDocument, TokenBasedDocument
+from pytorch_ie.core import Annotation, AnnotationList, Document, annotation_field
 
-from pie_modules.annotations import LabeledMultiSpan
+from pie_modules.annotations import LabeledMultiSpan, LabeledSpan
+from pie_modules.documents import TextBasedDocument, TokenBasedDocument
 from pie_modules.metrics import SpanCoverageCollector
 
 

--- a/tests/metrics/test_span_length_collector.py
+++ b/tests/metrics/test_span_length_collector.py
@@ -1,7 +1,7 @@
 import dataclasses
 
 import pytest
-from pytorch_ie.core import AnnotationList, Document, annotation_field
+from pytorch_ie.core import AnnotationLayer, Document, annotation_field
 
 from pie_modules.annotations import Label, LabeledSpan
 from pie_modules.documents import TextBasedDocument, TokenBasedDocument
@@ -12,7 +12,7 @@ from pie_modules.metrics import SpanLengthCollector
 def documents():
     @dataclasses.dataclass
     class TestDocument(TextBasedDocument):
-        entities: AnnotationList[LabeledSpan] = annotation_field(target="text")
+        entities: AnnotationLayer[LabeledSpan] = annotation_field(target="text")
 
     result = []
     doc = TestDocument(text="First sentence. Entity M works at N. And it founded O.")
@@ -81,7 +81,7 @@ def test_span_length_collector_wrong_label_value():
 def test_span_length_collector_with_tokenize(documents):
     @dataclasses.dataclass
     class TokenizedTestDocument(TokenBasedDocument):
-        entities: AnnotationList[LabeledSpan] = annotation_field(target="tokens")
+        entities: AnnotationLayer[LabeledSpan] = annotation_field(target="tokens")
 
     statistic = SpanLengthCollector(
         layer="entities",
@@ -129,7 +129,7 @@ def test_span_length_collector_with_tokenize_wrong_document_type():
     @dataclasses.dataclass
     class TestDocument(Document):
         data: str
-        entities: AnnotationList[LabeledSpan] = annotation_field(target="data")
+        entities: AnnotationLayer[LabeledSpan] = annotation_field(target="data")
 
     doc = TestDocument(data="First sentence. Entity M works at N. And it founded O.")
     doc.entities.append(LabeledSpan(start=16, end=24, label="per"))
@@ -137,7 +137,7 @@ def test_span_length_collector_with_tokenize_wrong_document_type():
 
     @dataclasses.dataclass
     class TokenizedTestDocument(TokenBasedDocument):
-        entities: AnnotationList[LabeledSpan] = annotation_field(target="tokens")
+        entities: AnnotationLayer[LabeledSpan] = annotation_field(target="tokens")
 
     statistic = SpanLengthCollector(
         layer="entities",
@@ -157,7 +157,7 @@ def test_span_length_collector_with_tokenize_wrong_document_type():
 def test_span_length_collector_with_tokenize_wrong_annotation_type():
     @dataclasses.dataclass
     class TestDocument(TextBasedDocument):
-        label: AnnotationList[Label] = annotation_field()
+        label: AnnotationLayer[Label] = annotation_field()
 
     doc = TestDocument(text="First sentence. Entity M works at N. And it founded O.")
     doc.label.append(Label(label="example"))

--- a/tests/metrics/test_span_length_collector.py
+++ b/tests/metrics/test_span_length_collector.py
@@ -1,11 +1,10 @@
 import dataclasses
 
 import pytest
-from pytorch_ie import Document
-from pytorch_ie.annotations import Label, LabeledSpan
-from pytorch_ie.core import AnnotationList, annotation_field
-from pytorch_ie.documents import TextBasedDocument, TokenBasedDocument
+from pytorch_ie.core import AnnotationList, Document, annotation_field
 
+from pie_modules.annotations import Label, LabeledSpan
+from pie_modules.documents import TextBasedDocument, TokenBasedDocument
 from pie_modules.metrics import SpanLengthCollector
 
 

--- a/tests/models/base_models/test_bart_as_pointer_network.py
+++ b/tests/models/base_models/test_bart_as_pointer_network.py
@@ -34,8 +34,8 @@ def config(config_str):
 
 @pytest.fixture(scope="module")
 def document():
-    from pytorch_ie.annotations import BinaryRelation, LabeledSpan
-    from pytorch_ie.documents import (
+    from pie_modules.annotations import BinaryRelation, LabeledSpan
+    from pie_modules.documents import (
         TextDocumentWithLabeledSpansBinaryRelationsAndLabeledPartitions,
     )
 

--- a/tests/taskmodules/common/test_interfaces.py
+++ b/tests/taskmodules/common/test_interfaces.py
@@ -1,7 +1,6 @@
 from typing import Any, Dict, List, Set, Tuple
 
-from pytorch_ie.annotations import Span
-
+from pie_modules.annotations import Span
 from pie_modules.taskmodules.common import AnnotationEncoderDecoder
 
 

--- a/tests/taskmodules/common/test_taskmodule_with_document_converter.py
+++ b/tests/taskmodules/common/test_taskmodule_with_document_converter.py
@@ -1,10 +1,10 @@
 from typing import Optional, Type
 
 import pytest
-from pytorch_ie import Document
-from pytorch_ie.documents import TextDocumentWithLabeledSpansAndBinaryRelations
+from pytorch_ie.core import Document
 from typing_extensions import TypeAlias
 
+from pie_modules.documents import TextDocumentWithLabeledSpansAndBinaryRelations
 from pie_modules.taskmodules import RETextClassificationWithIndicesTaskModule
 from pie_modules.taskmodules.common import TaskModuleWithDocumentConverter
 from tests.conftest import TestDocument

--- a/tests/taskmodules/metrics/test_precision_recall_and_f1_for_labeled_annotations.py
+++ b/tests/taskmodules/metrics/test_precision_recall_and_f1_for_labeled_annotations.py
@@ -1,7 +1,7 @@
 import pytest
-from pytorch_ie.annotations import LabeledSpan
 from torch import tensor
 
+from pie_modules.annotations import LabeledSpan
 from pie_modules.taskmodules.metrics import PrecisionRecallAndF1ForLabeledAnnotations
 
 

--- a/tests/taskmodules/pointer_network/test_annotation_encoder_decoder.py
+++ b/tests/taskmodules/pointer_network/test_annotation_encoder_decoder.py
@@ -1,6 +1,6 @@
 import pytest
-from pytorch_ie.annotations import BinaryRelation, LabeledSpan, Span
 
+from pie_modules.annotations import BinaryRelation, LabeledSpan, Span
 from pie_modules.taskmodules.pointer_network.annotation_encoder_decoder import (
     BinaryRelationEncoderDecoder,
     DecodingLabelException,

--- a/tests/taskmodules/test_cross_text_binary_coref.py
+++ b/tests/taskmodules/test_cross_text_binary_coref.py
@@ -4,10 +4,10 @@ from typing import Any, Dict, Union
 
 import pytest
 import torch.testing
-from pytorch_ie.annotations import LabeledSpan
 from torch import tensor
 from torchmetrics import Metric, MetricCollection
 
+from pie_modules.annotations import LabeledSpan
 from pie_modules.document.processing.text_pair import add_negative_coref_relations
 from pie_modules.documents import (
     BinaryCorefRelation,

--- a/tests/taskmodules/test_extractive_question_answering.py
+++ b/tests/taskmodules/test_extractive_question_answering.py
@@ -1,7 +1,7 @@
 import pytest
 import torch
 import transformers
-from pytorch_ie.core import AnnotationList
+from pytorch_ie.core import AnnotationLayer
 
 from pie_modules.annotations import ExtractiveAnswer, Question
 from pie_modules.documents import TextDocumentWithQuestionsAndExtractiveAnswers
@@ -114,14 +114,14 @@ def test_get_question_layer(taskmodule, document, document_with_no_answer):
     question_layer = taskmodule.get_question_layer(document)
     assert question_layer is not None
     assert len(question_layer) == 1
-    assert type(question_layer) is AnnotationList
+    assert type(question_layer) is AnnotationLayer
     assert type(question_layer[0]) is Question
     assert question_layer[0].text == "What is the first word?"
 
     question_layer = taskmodule.get_question_layer(document_with_no_answer)
     assert question_layer is not None
     assert len(question_layer) == 1
-    assert type(question_layer) is AnnotationList
+    assert type(question_layer) is AnnotationLayer
     assert type(question_layer[0]) is Question
     assert question_layer[0].text == "What is the first word?"
 
@@ -130,7 +130,7 @@ def test_get_answer_layer(taskmodule, document, document_with_no_answer):
     answer_layer = taskmodule.get_answer_layer(document)
     assert answer_layer is not None
     assert len(answer_layer) == 1
-    assert type(answer_layer) is AnnotationList
+    assert type(answer_layer) is AnnotationLayer
     assert type(answer_layer[0]) is ExtractiveAnswer
     assert answer_layer[0].question.text == "What is the first word?"
     assert answer_layer[0].start == 0
@@ -139,7 +139,7 @@ def test_get_answer_layer(taskmodule, document, document_with_no_answer):
     answer_layer = taskmodule.get_answer_layer(document_with_no_answer)
     assert answer_layer is not None
     assert len(answer_layer) == 0
-    assert type(answer_layer) is AnnotationList
+    assert type(answer_layer) is AnnotationLayer
 
 
 def test_get_context(taskmodule, document, document_with_no_answer):

--- a/tests/taskmodules/test_labeled_span_extraction_by_token_classification.py
+++ b/tests/taskmodules/test_labeled_span_extraction_by_token_classification.py
@@ -6,16 +6,16 @@ from typing import Any, Dict, List
 
 import pytest
 import torch
-from pytorch_ie import AnnotationLayer, annotation_field
-from pytorch_ie.annotations import LabeledSpan
-from pytorch_ie.documents import (
+from pytorch_ie.core import AnnotationLayer, annotation_field
+from torch import tensor
+from transformers import BatchEncoding
+
+from pie_modules.annotations import LabeledSpan
+from pie_modules.documents import (
     TextBasedDocument,
     TextDocumentWithLabeledSpans,
     TextDocumentWithLabeledSpansAndLabeledPartitions,
 )
-from torch import tensor
-from transformers import BatchEncoding
-
 from pie_modules.taskmodules import LabeledSpanExtractionByTokenClassificationTaskModule
 from pie_modules.taskmodules.labeled_span_extraction_by_token_classification import (
     ModelOutputType,

--- a/tests/taskmodules/test_pointer_network_for_end2end_re.py
+++ b/tests/taskmodules/test_pointer_network_for_end2end_re.py
@@ -5,7 +5,7 @@ from typing import Dict, List, Set
 
 import pytest
 import torch
-from pytorch_ie.core import AnnotationList, Document, annotation_field
+from pytorch_ie.core import AnnotationLayer, Document, annotation_field
 from transformers import LogitsProcessorList
 
 from pie_modules.annotations import BinaryRelation, LabeledSpan
@@ -44,9 +44,9 @@ def config(config_str):
 
 @dataclass
 class ExampleDocument(TextBasedDocument):
-    entities: AnnotationList[LabeledSpan] = annotation_field(target="text")
-    relations: AnnotationList[BinaryRelation] = annotation_field(target="entities")
-    sentences: AnnotationList[LabeledSpan] = annotation_field(target="text")
+    entities: AnnotationLayer[LabeledSpan] = annotation_field(target="text")
+    relations: AnnotationLayer[BinaryRelation] = annotation_field(target="entities")
+    sentences: AnnotationLayer[LabeledSpan] = annotation_field(target="text")
 
 
 @pytest.fixture(scope="module")

--- a/tests/taskmodules/test_pointer_network_for_end2end_re.py
+++ b/tests/taskmodules/test_pointer_network_for_end2end_re.py
@@ -5,11 +5,11 @@ from typing import Dict, List, Set
 
 import pytest
 import torch
-from pytorch_ie.annotations import BinaryRelation, LabeledSpan
 from pytorch_ie.core import AnnotationList, Document, annotation_field
-from pytorch_ie.documents import TextBasedDocument
 from transformers import LogitsProcessorList
 
+from pie_modules.annotations import BinaryRelation, LabeledSpan
+from pie_modules.documents import TextBasedDocument
 from pie_modules.taskmodules import PointerNetworkTaskModuleForEnd2EndRE
 from pie_modules.taskmodules.pointer_network.logits_processor import (
     PrefixConstrainedLogitsProcessorWithMaximum,

--- a/tests/taskmodules/test_re_span_pair_classification.py
+++ b/tests/taskmodules/test_re_span_pair_classification.py
@@ -4,12 +4,12 @@ from typing import Any, Dict, Union
 
 import pytest
 import torch
-from pytorch_ie import AnnotationLayer, annotation_field
-from pytorch_ie.annotations import BinaryRelation, LabeledSpan
-from pytorch_ie.documents import TextBasedDocument
+from pytorch_ie.core import AnnotationLayer, annotation_field
 from torch import tensor
 from torchmetrics import Metric, MetricCollection
 
+from pie_modules.annotations import BinaryRelation, LabeledSpan
+from pie_modules.documents import TextBasedDocument
 from pie_modules.taskmodules import RESpanPairClassificationTaskModule
 from pie_modules.utils import flatten_dict
 from pie_modules.utils.span import distance

--- a/tests/taskmodules/test_re_text_classification_with_indices.py
+++ b/tests/taskmodules/test_re_text_classification_with_indices.py
@@ -7,7 +7,6 @@ from typing import Any, Dict, List, Union
 
 import pytest
 import torch
-from pytorch_ie.annotations import BinaryRelation, LabeledSpan, NaryRelation
 from pytorch_ie.core import (
     Annotation,
     AnnotationList,
@@ -15,14 +14,14 @@ from pytorch_ie.core import (
     TaskEncoding,
     annotation_field,
 )
-from pytorch_ie.documents import (
-    TextBasedDocument,
-    TextDocument,
-    TextDocumentWithLabeledSpansAndBinaryRelations,
-)
 from torch import tensor
 from torchmetrics import Metric, MetricCollection
 
+from pie_modules.annotations import BinaryRelation, LabeledSpan, NaryRelation
+from pie_modules.documents import (
+    TextBasedDocument,
+    TextDocumentWithLabeledSpansAndBinaryRelations,
+)
 from pie_modules.taskmodules import RETextClassificationWithIndicesTaskModule
 from pie_modules.taskmodules.re_text_classification_with_indices import (
     HEAD,
@@ -2031,7 +2030,7 @@ def test_encode_nary_relatio():
     taskmodule._post_prepare()
 
     @dataclass
-    class DocWithNaryRelation(TextDocument):
+    class DocWithNaryRelation(TextBasedDocument):
         entities: AnnotationList[LabeledSpan] = annotation_field(target="text")
         relations: AnnotationList[NaryRelation] = annotation_field(target="entities")
 
@@ -2077,7 +2076,7 @@ def test_encode_unknown_relation_type():
         label: str
 
     @dataclass
-    class DocWithUnknownRelationType(TextDocument):
+    class DocWithUnknownRelationType(TextBasedDocument):
         entities: AnnotationList[LabeledSpan] = annotation_field(target="text")
         relations: AnnotationList[UnknownRelation] = annotation_field(target="entities")
 
@@ -2105,7 +2104,7 @@ def test_encode_with_unaligned_span(caplog):
     taskmodule._post_prepare()
 
     @dataclass
-    class MyDocument(TextDocument):
+    class MyDocument(TextBasedDocument):
         entities: AnnotationList[LabeledSpan] = annotation_field(target="text")
         relations: AnnotationList[BinaryRelation] = annotation_field(target="entities")
 
@@ -2138,7 +2137,7 @@ def test_encode_with_unaligned_span(caplog):
 
 def test_encode_with_log_first_n_examples(caplog):
     @dataclass
-    class DocumentWithLabeledEntitiesAndRelations(TextDocument):
+    class DocumentWithLabeledEntitiesAndRelations(TextBasedDocument):
         entities: AnnotationList[LabeledSpan] = annotation_field(target="text")
         relations: AnnotationList[BinaryRelation] = annotation_field(target="entities")
 

--- a/tests/taskmodules/test_re_text_classification_with_indices.py
+++ b/tests/taskmodules/test_re_text_classification_with_indices.py
@@ -9,7 +9,7 @@ import pytest
 import torch
 from pytorch_ie.core import (
     Annotation,
-    AnnotationList,
+    AnnotationLayer,
     Document,
     TaskEncoding,
     annotation_field,
@@ -1388,8 +1388,8 @@ def test_encode_input_with_add_candidate_relations(documents):
 def document_with_nary_relations():
     @dataclasses.dataclass
     class TestDocumentWithNaryRelations(TextBasedDocument):
-        entities: AnnotationList[LabeledSpan] = annotation_field(target="text")
-        relations: AnnotationList[NaryRelation] = annotation_field(target="entities")
+        entities: AnnotationLayer[LabeledSpan] = annotation_field(target="text")
+        relations: AnnotationLayer[NaryRelation] = annotation_field(target="entities")
 
     document = TestDocumentWithNaryRelations(
         text="Entity A works at B.", id="doc_with_nary_relations"
@@ -2031,8 +2031,8 @@ def test_encode_nary_relatio():
 
     @dataclass
     class DocWithNaryRelation(TextBasedDocument):
-        entities: AnnotationList[LabeledSpan] = annotation_field(target="text")
-        relations: AnnotationList[NaryRelation] = annotation_field(target="entities")
+        entities: AnnotationLayer[LabeledSpan] = annotation_field(target="text")
+        relations: AnnotationLayer[NaryRelation] = annotation_field(target="entities")
 
     doc = DocWithNaryRelation(text="hello my world")
     entity1 = LabeledSpan(start=0, end=5, label="a")
@@ -2077,8 +2077,8 @@ def test_encode_unknown_relation_type():
 
     @dataclass
     class DocWithUnknownRelationType(TextBasedDocument):
-        entities: AnnotationList[LabeledSpan] = annotation_field(target="text")
-        relations: AnnotationList[UnknownRelation] = annotation_field(target="entities")
+        entities: AnnotationLayer[LabeledSpan] = annotation_field(target="text")
+        relations: AnnotationLayer[UnknownRelation] = annotation_field(target="entities")
 
     doc = DocWithUnknownRelationType(text="hello world")
     entity = LabeledSpan(start=0, end=1, label="a")
@@ -2105,8 +2105,8 @@ def test_encode_with_unaligned_span(caplog):
 
     @dataclass
     class MyDocument(TextBasedDocument):
-        entities: AnnotationList[LabeledSpan] = annotation_field(target="text")
-        relations: AnnotationList[BinaryRelation] = annotation_field(target="entities")
+        entities: AnnotationLayer[LabeledSpan] = annotation_field(target="text")
+        relations: AnnotationLayer[BinaryRelation] = annotation_field(target="entities")
 
     doc = MyDocument(text="hello   space", id="doc1")
     entity1 = LabeledSpan(start=0, end=5, label="a")
@@ -2138,8 +2138,8 @@ def test_encode_with_unaligned_span(caplog):
 def test_encode_with_log_first_n_examples(caplog):
     @dataclass
     class DocumentWithLabeledEntitiesAndRelations(TextBasedDocument):
-        entities: AnnotationList[LabeledSpan] = annotation_field(target="text")
-        relations: AnnotationList[BinaryRelation] = annotation_field(target="entities")
+        entities: AnnotationLayer[LabeledSpan] = annotation_field(target="text")
+        relations: AnnotationLayer[BinaryRelation] = annotation_field(target="entities")
 
     doc = DocumentWithLabeledEntitiesAndRelations(text="hello world", id="doc1")
     entity1 = LabeledSpan(start=0, end=5, label="a")

--- a/tests/taskmodules/test_text2text.py
+++ b/tests/taskmodules/test_text2text.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, List, Sequence, Tuple
 
 import pytest
 import torch
-from pytorch_ie import Annotation, TaskEncoding
+from pytorch_ie.core import Annotation, TaskEncoding
 
 from pie_modules.annotations import AbstractiveSummary
 from pie_modules.documents import (

--- a/tests/taskmodules/test_text2text_with_guidance.py
+++ b/tests/taskmodules/test_text2text_with_guidance.py
@@ -2,7 +2,7 @@ from typing import Any, Dict, List, Sequence, Tuple
 
 import pytest
 import torch
-from pytorch_ie import Annotation, TaskEncoding
+from pytorch_ie.core import Annotation, TaskEncoding
 
 from pie_modules.annotations import GenerativeAnswer, Question
 from pie_modules.documents import (

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -2,7 +2,7 @@ import json
 from typing import Dict, Optional
 
 import pytest
-from pytorch_ie import Annotation
+from pytorch_ie.core import Annotation
 
 from pie_modules.annotations import LabeledMultiSpan
 

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -1,6 +1,9 @@
-from pytorch_ie.annotations import BinaryRelation, LabeledSpan
-
-from pie_modules.annotations import ExtractiveAnswer, Question
+from pie_modules.annotations import (
+    BinaryRelation,
+    ExtractiveAnswer,
+    LabeledSpan,
+    Question,
+)
 from pie_modules.documents import (
     TextDocumentWithQuestionsAndExtractiveAnswers,
     TokenDocumentWithLabeledPartitions,

--- a/tests/utils/test_hydra.py
+++ b/tests/utils/test_hydra.py
@@ -1,10 +1,10 @@
 import dataclasses
 
 import pytest
-from pytorch_ie import AnnotationLayer, annotation_field
-from pytorch_ie.annotations import LabeledSpan, Span
-from pytorch_ie.documents import TextBasedDocument
+from pytorch_ie.core import AnnotationLayer, annotation_field
 
+from pie_modules.annotations import LabeledSpan, Span
+from pie_modules.documents import TextBasedDocument
 from pie_modules.utils import resolve_type
 
 

--- a/tests/utils/test_tokenization.py
+++ b/tests/utils/test_tokenization.py
@@ -1,7 +1,7 @@
 import pytest
-from pytorch_ie.annotations import Span
 from transformers import AutoTokenizer
 
+from pie_modules.annotations import Span
 from pie_modules.utils.tokenization import (
     SpanNotAlignedWithTokenException,
     get_aligned_token_span,


### PR DESCRIPTION
- use `annotations` and `documents` from `pie_modules`
- import never from `pytorch_ie` root (except `PyTorchIEModel`)
- don't use `AnnotationList` anymore (use `AnnotationLayer` instead)