### PR TITLE
improve `utils.sequence_tagging.encoding` (typing and docs)

### DIFF
--- a/src/pie_modules/utils/sequence_tagging/encoding.py
+++ b/src/pie_modules/utils/sequence_tagging/encoding.py
@@ -205,7 +205,7 @@ def iob2_tags_to_spans(
         which should be ignored when extracting the spans.
     # Returns
     spans : `List[TypedStringSpan]`
-        The typed, extracted spans from the sequence, in the format (label, (span_start, span_end)).
+        The typed, extracted spans from the sequence, in the format (label, (span_start, span_end_inclusive)).
         Note that the label `does not` contain any IOB2 tag prefixes.
     """
     spans = []
@@ -255,7 +255,7 @@ def bioul_tags_to_spans(
 
     # Returns
     spans : `List[TypedStringSpan]`
-        The typed, extracted spans from the sequence, in the format (label, (span_start, span_end)).
+        The typed, extracted spans from the sequence, in the format (label, (span_start, span_end_inclusive)).
     """
 
     spans = []
@@ -295,7 +295,7 @@ def boul_tags_to_spans(
 
     # Returns
     spans : `List[TypedStringSpan]`
-        The typed, extracted spans from the sequence, in the format (label, (span_start, span_end)).
+        The typed, extracted spans from the sequence, in the format (label, (span_start, span_end_inclusive)).
     """
     bioul_tags = _boul_to_bioul(tag_sequence=tag_sequence)
     return bioul_tags_to_spans(
@@ -376,7 +376,7 @@ def tag_sequence_to_token_spans(
             (if True) or removed (if False)
        # Returns
        spans : `List[TypedStringSpan]`
-           The typed, extracted spans from the sequence, in the format (label, (span_start, span_end)).
+           The typed, extracted spans from the sequence, in the format (label, (span_start, span_end_inclusive)).
     """
 
     if include_ill_formed:

--- a/src/pie_modules/utils/sequence_tagging/encoding.py
+++ b/src/pie_modules/utils/sequence_tagging/encoding.py
@@ -282,7 +282,7 @@ def bioul_tags_to_spans(
 def boul_tags_to_spans(
     tag_sequence: List[str],
     classes_to_ignore: Optional[List[str]] = None,
-):
+) -> List[TypedStringSpan]:
     """Given a sequence corresponding to BOUL tags, extracts spans. It converts BOUL tags to BIOUL
     tags and then BIOUL tags are converted to spans.
 
@@ -358,7 +358,7 @@ def tag_sequence_to_token_spans(
     coding_scheme: str = "IOB2",
     classes_to_ignore: Optional[List[str]] = None,
     include_ill_formed: bool = True,
-):
+) -> List[TypedStringSpan]:
     """Given a sequence corresponding to a coding scheme (IOB2, BIOUL and BOUL), this method
     converts it into the token spans. It first fixes or removes the ill formed tag sequence (if
     any) and then converts the tag sequence to the spans.


### PR DESCRIPTION
-  add return types to `boul_tags_to_spans` and to `tag_sequence_to_token_spans`
-  clarify that decoded span ends are inclusive (`iob2_tags_to_spans`, `bioul_tags_to_spans`, `boul_tags_to_spans`, `tag_sequence_to_token_spans`)

