### PR TITLE
Fix confusion of unassignable and undetected label in confusion matrix

### DIFF
--- a/src/pie_modules/metrics/confusion_matrix.py
+++ b/src/pie_modules/metrics/confusion_matrix.py
@@ -81,14 +81,14 @@ class ConfusionMatrix(DocumentMetric):
             gold_labels = [getattr(ann, self.label_field) for ann in base2gold[base_ann]]
             pred_labels = [getattr(ann, self.label_field) for ann in base2pred[base_ann]]
 
-            if self.undetected_label in gold_labels:
+            if self.unassignable_label in gold_labels:
                 raise ValueError(
-                    f"The gold annotation has the label '{self.undetected_label}' for undetected instances. "
+                    f"The gold annotation has the label '{self.unassignable_label}' for unassignable instances. "
                     f"Set a different undetected_label."
                 )
-            if self.unassignable_label in pred_labels:
+            if self.undetected_label in pred_labels:
                 raise ValueError(
-                    f"The predicted annotation has the label '{self.unassignable_label}' for unassignable predictions. "
+                    f"The predicted annotation has the label '{self.undetected_label}' for undetected instances. "
                     f"Set a different unassignable_label."
                 )
 
@@ -102,9 +102,9 @@ class ConfusionMatrix(DocumentMetric):
 
             # use placeholder labels for empty gold or prediction labels
             if len(gold_labels) == 0:
-                gold_labels.append(self.undetected_label)
+                gold_labels.append(self.unassignable_label)
             if len(pred_labels) == 0:
-                pred_labels.append(self.unassignable_label)
+                pred_labels.append(self.undetected_label)
 
             # main logic
             for gold_label in gold_labels:

--- a/src/pie_modules/metrics/confusion_matrix.py
+++ b/src/pie_modules/metrics/confusion_matrix.py
@@ -84,12 +84,12 @@ class ConfusionMatrix(DocumentMetric):
             if self.unassignable_label in gold_labels:
                 raise ValueError(
                     f"The gold annotation has the label '{self.unassignable_label}' for unassignable instances. "
-                    f"Set a different undetected_label."
+                    f"Set a different unassignable_label."
                 )
             if self.undetected_label in pred_labels:
                 raise ValueError(
                     f"The predicted annotation has the label '{self.undetected_label}' for undetected instances. "
-                    f"Set a different unassignable_label."
+                    f"Set a different undetected_label."
                 )
 
             if len(gold_labels) > 1:

--- a/tests/metrics/test_confusion_matrix.py
+++ b/tests/metrics/test_confusion_matrix.py
@@ -53,18 +53,18 @@ def test_confusion_matrix(documents):
     assert dict(metric.counts) == {
         ("animal", "animal"): 1,
         ("animal", "cat"): 1,
-        ("UNDETECTED", "company"): 1,
+        ("UNASSIGNABLE", "company"): 1,
         ("company", "company"): 1,
     }
     assert metric.compute() == {
         "animal": {"animal": 1, "cat": 1},
-        "UNDETECTED": {"company": 1},
+        "UNASSIGNABLE": {"company": 1},
         "company": {"company": 1},
     }
 
 
 def test_undetected_is_gold_label(documents):
-    metric = ConfusionMatrix(layer="entities", undetected_label="animal")
+    metric = ConfusionMatrix(layer="entities", unassignable_label="animal")
     with pytest.raises(ValueError) as exception:
         metric(documents)
 
@@ -72,7 +72,7 @@ def test_undetected_is_gold_label(documents):
 
 
 def test_unassignable_is_pred_label(documents):
-    metric = ConfusionMatrix(layer="entities", unassignable_label="cat")
+    metric = ConfusionMatrix(layer="entities", undetected_label="cat")
     with pytest.raises(ValueError) as exception:
         metric(documents)
 
@@ -114,7 +114,7 @@ def documents_without_predictions(documents):
 def test_documents_without_predictions(documents_without_predictions):
     metric = ConfusionMatrix(layer="entities")
     metric(documents_without_predictions)
-    assert dict(metric.counts) == {("animal", "UNASSIGNABLE"): 2, ("company", "UNASSIGNABLE"): 1}
+    assert dict(metric.counts) == {("animal", "UNDETECTED"): 2, ("company", "UNDETECTED"): 1}
 
 
 def test_show_as_markdown(documents, caplog):
@@ -123,9 +123,8 @@ def test_show_as_markdown(documents, caplog):
     metric(documents)
 
     markdown = [
-        "\nentities:\n|            |   animal |   cat |   company |\n|:-----------|---------:|------:|----------:|\n| animal     |        1 |     1 |         0 |\n| company    |        0 |     0 |         1 |\n| UNDETECTED |        0 |     0 |         1 |"
+        "\nentities:\n|              |   animal |   cat |   company |\n|:-------------|---------:|------:|----------:|\n| UNASSIGNABLE |        0 |     0 |         1 |\n| animal       |        1 |     1 |         0 |\n| company      |        0 |     0 |         1 |"
     ]
-
     assert caplog.messages == markdown
 
 
@@ -135,7 +134,7 @@ def test_show_as_markdown_without_predictions(documents_without_predictions, cap
     metric(documents_without_predictions)
 
     markdown = [
-        "\nentities:\n|         |   UNASSIGNABLE |\n|:--------|---------------:|\n| animal  |              2 |\n| company |              1 |"
+        "\nentities:\n|         |   UNDETECTED |\n|:--------|-------------:|\n| animal  |            2 |\n| company |            1 |"
     ]
 
     assert caplog.messages == markdown
@@ -160,7 +159,7 @@ def test_annotation_processor(documents):
         ("Hrrr", "My beautified Cat"): 1,
         ("Hrrr", "Hrrr"): 1,
         ("The Super-Company", "The Super-Company"): 1,
-        ("UNDETECTED", "The Super-Company"): 1,
+        ("UNASSIGNABLE", "The Super-Company"): 1,
     }
 
 
@@ -173,5 +172,5 @@ def test_annotation_processor_str(documents):
         ("Hrrr", "My beautified Cat"): 1,
         ("Hrrr", "Hrrr"): 1,
         ("The Super-Company", "The Super-Company"): 1,
-        ("UNDETECTED", "The Super-Company"): 1,
+        ("UNASSIGNABLE", "The Super-Company"): 1,
     }

--- a/tests/metrics/test_confusion_matrix.py
+++ b/tests/metrics/test_confusion_matrix.py
@@ -68,7 +68,10 @@ def test_undetected_is_gold_label(documents):
     with pytest.raises(ValueError) as exception:
         metric(documents)
 
-    assert str(exception.value).startswith("The gold annotation has the label")
+    assert (
+        str(exception.value)
+        == "The gold annotation has the label 'animal' for unassignable instances. Set a different unassignable_label."
+    )
 
 
 def test_unassignable_is_pred_label(documents):
@@ -76,7 +79,10 @@ def test_unassignable_is_pred_label(documents):
     with pytest.raises(ValueError) as exception:
         metric(documents)
 
-    assert str(exception.value).startswith("The predicted annotation has the label")
+    assert (
+        str(exception.value)
+        == "The predicted annotation has the label 'cat' for undetected instances. Set a different undetected_label."
+    )
 
 
 @pytest.fixture


### PR DESCRIPTION
This PR fixes the labels for UNDETECTED and UNASSIGNABLE for the `confusion matrix`. Here is the reasoning:

* `UNDETECTED` = false negatives
    * samples that are positive (binary) or have a class label other than `no-relation` (multiclass), but were not detected by the classifier and not labeled. In this case there is a gold label for the sample, but no corresponding pred label
* `UNASSIGNABLE` = false positives
    * samples that are negative (binary) or have the label `no-relation` (multiclass), but got a positive or existing class label from the classifier. In this case there is no gold label for the sample, but a pred label does exist