### PR TITLE
implement `SpanMeanPooler` and add it to `get_pooler_and_output_size` logic

### DIFF
--- a/src/pie_modules/models/components/pooler.py
+++ b/src/pie_modules/models/components/pooler.py
@@ -269,6 +269,6 @@ def get_pooler_and_output_size(config: Dict[str, Any], input_dim: int) -> Tuple[
             pooler = SpanMeanPooler(input_dim=input_dim, **pooler_config)
             return pooler, pooler.output_dim
         else:
-            raise ValueError(f"Unknown aggregation method for mention pooling: {aggregate}")
+            raise ValueError(f'Unknown aggregation method for mention pooling: "{aggregate}"')
     else:
         raise ValueError(f'Unknown pooler type "{pooler_type}"')

--- a/src/pie_modules/models/components/pooler.py
+++ b/src/pie_modules/models/components/pooler.py
@@ -172,6 +172,83 @@ class SpanMaxPooler(nn.Module):
         return self.input_dim * self.num_indices
 
 
+class SpanMeanPooler(nn.Module):
+    """Pooler that takes the mean hidden state over spans. If the start or end index is negative, a
+    learned embedding is used. The indices are expected to have the shape [batch_size,
+    num_indices].
+
+    The resulting embeddings are concatenated, so the output shape is [batch_size, num_indices * input_dim].
+    Note this a slightly modified version of the pie_modules.models.components.pooler.SpanMaxPooler,
+    i.e. we changed the aggregation method from torch.amax to torch.mean.
+
+    Args:
+        input_dim: The input dimension of the hidden state.
+        num_indices: The number of indices to pool.
+
+    Returns:
+        The pooled hidden states with shape [batch_size, num_indices * input_dim].
+    """
+
+    def __init__(self, input_dim: int, num_indices: int = 2, **kwargs):
+        super().__init__(**kwargs)
+        self.input_dim = input_dim
+        self.num_indices = num_indices
+        self.missing_embeddings = nn.Parameter(torch.empty(num_indices, self.input_dim))
+        nn.init.normal_(self.missing_embeddings)
+
+    def forward(
+        self, hidden_state: Tensor, start_indices: Tensor, end_indices: Tensor, **kwargs
+    ) -> Tensor:
+        batch_size, seq_len, hidden_size = hidden_state.shape
+        if start_indices.shape[1] != self.num_indices:
+            raise ValueError(
+                f"number of start indices [{start_indices.shape[1]}] has to be the same as num_types [{self.num_indices}]"
+            )
+
+        if end_indices.shape[1] != self.num_indices:
+            raise ValueError(
+                f"number of end indices [{end_indices.shape[1]}] has to be the same as num_types [{self.num_indices}]"
+            )
+
+        # check that start_indices are before end_indices
+        mask_both_positive = (start_indices >= 0) & (end_indices >= 0)
+        mask_start_before_end = start_indices < end_indices
+        mask_valid = mask_start_before_end | ~mask_both_positive
+        if not torch.all(mask_valid):
+            raise ValueError(
+                f"values in start_indices have to be smaller than respective values in "
+                f"end_indices, but start_indices=\n{start_indices}\n and end_indices=\n{end_indices}"
+            )
+
+        # times num_indices due to concat
+        result = torch.zeros(
+            batch_size, hidden_size * self.num_indices, device=hidden_state.device
+        )
+        for batch_idx in range(batch_size):
+            current_start_indices = start_indices[batch_idx]
+            current_end_indices = end_indices[batch_idx]
+            current_embeddings = [
+                (
+                    torch.mean(
+                        hidden_state[
+                            batch_idx, current_start_indices[i] : current_end_indices[i], :
+                        ],
+                        dim=0,
+                    )
+                    if current_start_indices[i] >= 0 and current_end_indices[i] >= 0
+                    else self.missing_embeddings[i]
+                )
+                for i in range(self.num_indices)
+            ]
+            result[batch_idx] = cat(current_embeddings, 0)
+
+        return result
+
+    @property
+    def output_dim(self) -> int:
+        return self.input_dim * self.num_indices
+
+
 def get_pooler_and_output_size(config: Dict[str, Any], input_dim: int) -> Tuple[Callable, int]:
     pooler_config = dict(config)
     pooler_type = pooler_config.pop("type", CLS_TOKEN)
@@ -184,7 +261,14 @@ def get_pooler_and_output_size(config: Dict[str, Any], input_dim: int) -> Tuple[
         )
         return pooler_wrapped, pooler.output_dim
     elif pooler_type == MENTION_POOLING:
-        pooler = SpanMaxPooler(input_dim=input_dim, **pooler_config)
-        return pooler, pooler.output_dim
+        aggregate = pooler_config.pop("aggregate", "max")
+        if aggregate == "max":
+            pooler = SpanMaxPooler(input_dim=input_dim, **pooler_config)
+            return pooler, pooler.output_dim
+        elif aggregate == "mean":
+            pooler = SpanMeanPooler(input_dim=input_dim, **pooler_config)
+            return pooler, pooler.output_dim
+        else:
+            raise ValueError(f"Unknown aggregation method for mention pooling: {aggregate}")
     else:
         raise ValueError(f'Unknown pooler type "{pooler_type}"')

--- a/tests/models/components/test_pooler.py
+++ b/tests/models/components/test_pooler.py
@@ -49,6 +49,14 @@ def test_get_pooler_and_output_size_mention(aggregate):
         raise ValueError(f"Unknown aggregate type {aggregate}")
 
 
+def test_get_pooler_and_output_size_mention_unknown_aggregate():
+    with pytest.raises(ValueError) as excinfo:
+        get_pooler_and_output_size(
+            config={"type": MENTION_POOLING, "aggregate": "unknown"}, input_dim=20
+        )
+    assert str(excinfo.value) == 'Unknown aggregation method for mention pooling: "unknown"'
+
+
 def test_get_pooler_and_output_size_wrong_type():
     with pytest.raises(ValueError) as excinfo:
         get_pooler_and_output_size(config={"type": "wrong_type"}, input_dim=20)

--- a/tests/models/components/test_pooler.py
+++ b/tests/models/components/test_pooler.py
@@ -8,6 +8,7 @@ from pie_modules.models.components.pooler import (
     ArgumentWrappedPooler,
     AtIndexPooler,
     SpanMaxPooler,
+    SpanMeanPooler,
     get_pooler_and_output_size,
     pool_cls,
 )
@@ -176,4 +177,19 @@ def test_span_max_pooler_start_indices_bigger_than_end_indices(hidde_state):
         "and end_indices=\n"
         "tensor([[1, 3],\n"
         "        [1, 2]])"
+    )
+
+
+def test_span_mean_pooler(hidde_state):
+    pooler = SpanMeanPooler(input_dim=hidde_state.shape[-1], num_indices=2)
+    start_indices = torch.tensor([[2, 0], [0, 1]])
+    end_indices = torch.tensor([[3, 3], [1, 2]])
+    output = pooler(hidden_state=hidde_state, start_indices=start_indices, end_indices=end_indices)
+    assert output is not None
+    batch_size = hidde_state.shape[0]
+    hidden_size = hidde_state.shape[-1]
+    # times num_indices (=2) due to concat
+    assert output.shape == (batch_size, hidden_size * 2)
+    torch.testing.assert_close(
+        output, torch.tensor([[0.20, 0.21, 0.10, 0.11], [1.00, 1.01, 1.10, 1.11]])
     )

--- a/tests/models/components/test_pooler.py
+++ b/tests/models/components/test_pooler.py
@@ -34,6 +34,21 @@ def test_get_pooler_and_output_size(pooler_type):
         raise ValueError(f"Unknown pooler type {pooler_type}")
 
 
+@pytest.mark.parametrize("aggregate", ["max", "mean"])
+def test_get_pooler_and_output_size_mention(aggregate):
+    pooler, output_size = get_pooler_and_output_size(
+        config={"type": MENTION_POOLING, "aggregate": aggregate}, input_dim=20
+    )
+    assert pooler is not None
+    assert output_size == 20 * 2
+    if aggregate == "max":
+        assert isinstance(pooler, SpanMaxPooler)
+    elif aggregate == "mean":
+        assert isinstance(pooler, SpanMeanPooler)
+    else:
+        raise ValueError(f"Unknown aggregate type {aggregate}")
+
+
 def test_get_pooler_and_output_size_wrong_type():
     with pytest.raises(ValueError) as excinfo:
         get_pooler_and_output_size(config={"type": "wrong_type"}, input_dim=20)


### PR DESCRIPTION
This allows to pass a parameter `aggregate` to the pooler config:
 - `max` (default): create a `SpanMaxPooler` (as before)
 - `mean`: create a `SpanMeanPooler`