### PR TITLE
fix bug in `taskmodules/common/mixins.py/RelationStatisticsMixin/format_statistics()`

### DIFF
--- a/src/pie_modules/taskmodules/common/mixins.py
+++ b/src/pie_modules/taskmodules/common/mixins.py
@@ -257,13 +257,13 @@ class RelationStatisticsMixin(StatisticsMixin[Dict[Tuple[str, str], int]]):
             return {}
 
     def format_statistics(self, statistics: Dict[Tuple[str, str], int]) -> str:
-        to_show_series = pd.Series(statistics)
         if len(statistics) > 0:
+            to_show_series = pd.Series(statistics)
             # unstack index to have relation labels as column names
             to_show = to_show_series.unstack()
         else:
             # If there were no statistics, create an empty dummy dataframe.
-            to_show = pd.DataFrame(to_show_series)
+            to_show = pd.DataFrame(pd.Series(dict()))
         # fill missing values with 0 and convert back to int (unstacking may introduce NaNs which are float type)
         to_show = to_show.fillna(0).astype(int)
         if to_show.columns.size > 1:

--- a/src/pie_modules/taskmodules/common/mixins.py
+++ b/src/pie_modules/taskmodules/common/mixins.py
@@ -257,9 +257,13 @@ class RelationStatisticsMixin(StatisticsMixin[Dict[Tuple[str, str], int]]):
             return {}
 
     def format_statistics(self, statistics: Dict[Tuple[str, str], int]) -> str:
+        # Statistics are converted to Series and then unstacked giving us the right DataFrame we need.
+        # If there were no statistics - unstack will fail, so we manually convert to DataFrame.
         to_show = pd.Series(statistics)
-        if len(to_show.index.names) > 1:
+        if len(to_show.index) > 0:
             to_show = to_show.unstack()
+        else:
+            to_show = pd.DataFrame(to_show)
         # fill missing values with 0 and convert back to int (unstacking may introduce NaNs which are float type)
         to_show = to_show.fillna(0).astype(int)
         if to_show.columns.size > 1:

--- a/src/pie_modules/taskmodules/common/mixins.py
+++ b/src/pie_modules/taskmodules/common/mixins.py
@@ -200,7 +200,7 @@ class RelationStatisticsMixin:
             if len(to_show.index.names) > 1:
                 to_show = to_show.unstack()
             to_show = to_show.fillna(0)
-            if to_show.columns.size > 1:
+            if isinstance(to_show, pd.DataFrame) and to_show.columns.size > 1:
                 to_show["all_relations"] = to_show.loc[:, to_show.columns != "no_relation"].sum(
                     axis=1
                 )

--- a/src/pie_modules/taskmodules/common/mixins.py
+++ b/src/pie_modules/taskmodules/common/mixins.py
@@ -257,13 +257,13 @@ class RelationStatisticsMixin(StatisticsMixin[Dict[Tuple[str, str], int]]):
             return {}
 
     def format_statistics(self, statistics: Dict[Tuple[str, str], int]) -> str:
-        # Statistics are converted to Series and then unstacked giving us the right DataFrame we need.
-        # If there were no statistics - unstack will fail, so we manually convert to DataFrame.
-        to_show = pd.Series(statistics)
-        if len(to_show.index) > 0:
-            to_show = to_show.unstack()
+        to_show_series = pd.Series(statistics)
+        if len(statistics) > 0:
+            # unstack index to have relation labels as column names
+            to_show = to_show_series.unstack()
         else:
-            to_show = pd.DataFrame(to_show)
+            # If there were no statistics, create an empty dummy dataframe.
+            to_show = pd.DataFrame(to_show_series)
         # fill missing values with 0 and convert back to int (unstacking may introduce NaNs which are float type)
         to_show = to_show.fillna(0).astype(int)
         if to_show.columns.size > 1:

--- a/src/pie_modules/taskmodules/common/mixins.py
+++ b/src/pie_modules/taskmodules/common/mixins.py
@@ -200,7 +200,7 @@ class RelationStatisticsMixin:
             if len(to_show.index.names) > 1:
                 to_show = to_show.unstack()
             to_show = to_show.fillna(0)
-            if isinstance(to_show, pd.DataFrame) and to_show.columns.size > 1:
+            if to_show.columns.size > 1:
                 to_show["all_relations"] = to_show.loc[:, to_show.columns != "no_relation"].sum(
                     axis=1
                 )

--- a/tests/taskmodules/common/test_mixins.py
+++ b/tests/taskmodules/common/test_mixins.py
@@ -79,17 +79,10 @@ def test_relation_statistics_mixin_show_statistics(caplog):
 def test_relation_statistics_mixin_show_statistics_no_relations(caplog):
     """Test the RelationStatisticsMixin class."""
 
-    @dataclasses.dataclass
     class Foo(RelationStatisticsMixin):
         """A class that uses the RelationStatisticsMixin class."""
 
-        def __init__(self, *args, **kwargs):
-            super().__init__(*args, **kwargs)
-
-    @dataclasses.dataclass(eq=True, frozen=True)
-    class TestAnnotation(Annotation):
-        label: str
-        score: float = dataclasses.field(default=1.0, compare=False)
+        pass
 
     x = Foo(collect_statistics=True)
 

--- a/tests/taskmodules/common/test_mixins.py
+++ b/tests/taskmodules/common/test_mixins.py
@@ -1,9 +1,12 @@
 import dataclasses
+import logging
 from typing import List
 
 import torch
+from pytorch_ie import Annotation
 
 from pie_modules.taskmodules.common import BatchableMixin
+from pie_modules.taskmodules.common.mixins import RelationStatisticsMixin
 
 
 def test_batchable_mixin():
@@ -29,3 +32,54 @@ def test_batchable_mixin():
     )
     torch.testing.assert_close(batch["a"], torch.tensor([[1, 2, 3], [4, 5, 0]]))
     torch.testing.assert_close(batch["len_a"], torch.tensor([3, 2]))
+
+
+def test_relation_statistics_mixin_show_statistics(caplog):
+    """Test the RelationStatisticsMixin class."""
+
+    @dataclasses.dataclass
+    class Foo(RelationStatisticsMixin):
+        """A class that uses the RelationStatisticsMixin class."""
+
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+
+    @dataclasses.dataclass(eq=True, frozen=True)
+    class TestAnnotation(Annotation):
+        label: str
+        score: float = dataclasses.field(default=1.0, compare=False)
+
+    x = Foo(collect_statistics=True)
+
+    # Test with no relations collected
+    x.collect_all_relations(kind="available", relations=[])
+    x.collect_all_relations(kind="used", relations=[])
+    with caplog.at_level(logging.INFO):
+        x.show_statistics()
+    assert caplog.messages[0] == ("statistics:\n" "| 0   |\n" "|-----|")
+
+    # Test Regular case
+    x.reset_statistics()
+    relations = [
+        TestAnnotation(label="A", score=1),
+        TestAnnotation(label="B", score=0.5),
+        TestAnnotation(label="C", score=0.3),
+    ]
+    x.collect_all_relations(kind="available", relations=relations)
+    x.collect_relation(kind="skipped_test", relation=relations[1])
+    x.collect_all_relations(
+        kind="used",
+        relations=set(x._collected_relations["available"])
+        - set(x._collected_relations["skipped_test"]),
+    )
+    with caplog.at_level(logging.INFO):
+        x.show_statistics()
+    assert caplog.messages[1] == (
+        "statistics:\n"
+        "|              |   A |   B |   C |   all_relations |\n"
+        "|:-------------|----:|----:|----:|----------------:|\n"
+        "| available    |   1 |   1 |   1 |               3 |\n"
+        "| skipped_test |   0 |   1 |   0 |               1 |\n"
+        "| used         |   1 |   0 |   1 |               2 |\n"
+        "| used %       | 100 |   0 | 100 |              67 |"
+    )

--- a/tests/taskmodules/common/test_mixins.py
+++ b/tests/taskmodules/common/test_mixins.py
@@ -51,15 +51,6 @@ def test_relation_statistics_mixin_show_statistics(caplog):
 
     x = Foo(collect_statistics=True)
 
-    # Test with no relations collected
-    x.collect_all_relations(kind="available", relations=[])
-    x.collect_all_relations(kind="used", relations=[])
-    with caplog.at_level(logging.INFO):
-        x.show_statistics()
-    assert caplog.messages[0] == ("statistics:\n" "| 0   |\n" "|-----|")
-
-    # Test Regular case
-    x.reset_statistics()
     relations = [
         TestAnnotation(label="A", score=1),
         TestAnnotation(label="B", score=0.5),
@@ -74,7 +65,7 @@ def test_relation_statistics_mixin_show_statistics(caplog):
     )
     with caplog.at_level(logging.INFO):
         x.show_statistics()
-    assert caplog.messages[1] == (
+    assert caplog.messages[0] == (
         "statistics:\n"
         "|              |   A |   B |   C |   all_relations |\n"
         "|:-------------|----:|----:|----:|----------------:|\n"
@@ -83,3 +74,28 @@ def test_relation_statistics_mixin_show_statistics(caplog):
         "| used         |   1 |   0 |   1 |               2 |\n"
         "| used %       | 100 |   0 | 100 |              67 |"
     )
+
+
+def test_relation_statistics_mixin_show_statistics_no_relations(caplog):
+    """Test the RelationStatisticsMixin class."""
+
+    @dataclasses.dataclass
+    class Foo(RelationStatisticsMixin):
+        """A class that uses the RelationStatisticsMixin class."""
+
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+
+    @dataclasses.dataclass(eq=True, frozen=True)
+    class TestAnnotation(Annotation):
+        label: str
+        score: float = dataclasses.field(default=1.0, compare=False)
+
+    x = Foo(collect_statistics=True)
+
+    # Test with no relations collected
+    x.collect_all_relations(kind="available", relations=[])
+    x.collect_all_relations(kind="used", relations=[])
+    with caplog.at_level(logging.INFO):
+        x.show_statistics()
+    assert caplog.messages[0] == ("statistics:\n" "| 0   |\n" "|-----|")


### PR DESCRIPTION
This PR fixes a bug introduced in #92 
Error found [here](https://github.com/bayer-int/nlp-at-scale-user-dictionaries/pull/44#discussion_r2084351044)

## Changes
- src/taskmodules/common/mixins.py:
  - `to_show` is now always of type `DataFrame`
  - use `unstack()` only if `statistics` is not empty
- tests/taskmodules/common/test_mixins.py
  - add test case for empty statistics 

## Bug description:

https://github.com/ArneBinder/pie-modules/blob/00c88cae6a9ed576715503019219d7f4bce277fe/src/pie_modules/taskmodules/common/mixins.py#L259-L265
 
Variable `to_show` may have different types (`Series` or `DataFrame`) depending on check in L261, causing
error in L265: `AttributeError: 'Series' object has no attribute 'columns'`

NOTES/TODO:
- [X] add tests for mixin