### PR TITLE
make dev dependencies optional

### DIFF
--- a/.github/workflows/code-quality-main.yaml
+++ b/.github/workflows/code-quality-main.yaml
@@ -48,7 +48,7 @@ jobs:
       #----------------------------------------------
       - name: Install dependencies
         if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
-        run: poetry install --no-interaction --no-root
+        run: poetry install --with dev --no-interaction --no-root
 
       - name: Run pre-commits
         uses: pre-commit/action@v3.0.1

--- a/.github/workflows/code-quality-pr.yaml
+++ b/.github/workflows/code-quality-pr.yaml
@@ -51,7 +51,7 @@ jobs:
       #----------------------------------------------
       - name: Install dependencies
         if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
-        run: poetry install --no-interaction --no-root
+        run: poetry install --with dev --no-interaction --no-root
 
       #----------------------------------------------
       # find and list modified files

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -56,7 +56,7 @@ jobs:
       #----------------------------------------------
       - name: Install dependencies
         if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
-        run: poetry install --no-interaction --no-root
+        run: poetry install --with dev --no-interaction --no-root
 
       #----------------------------------------------
       # install your root project, if required

--- a/README.md
+++ b/README.md
@@ -72,9 +72,9 @@ pip install git+https://git@github.com/ArneBinder/pie-modules.git
    git clone https://github.com/ArneBinder/pie-modules
    cd pie-modules
    ```
-3. Create a virtual environment and install the dependencies:
+3. Create a virtual environment and install the dependencies (including development dependencies):
    ```bash
-   poetry install
+   poetry install --with dev
    ```
 
 Finally, to run any of the below commands, you need to activate the virtual environment:

--- a/poetry.lock
+++ b/poetry.lock
@@ -3439,4 +3439,4 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "9edc2e1c448159e3f55c1d7fb1c6fa1d2baa9a11b2ef6e8aa80d5f551789ecac"
+content-hash = "d4692a47e77f909acc341aac181df02da930d6f8270214f105b0bdd6695f2b2d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,9 @@ flair = "^0.13.1"
 # for SpansViaRelationMerger
 networkx = "^3.0.0"
 
+[tool.poetry.group.dev]
+optional = true
+
 [[tool.poetry.source]]
 name = "pytorch"
 url = "https://download.pytorch.org/whl/cpu"


### PR DESCRIPTION
The `dev` dependencies should not be installed per default in any packages that require `pie-core`.

After this, it is required to install via `poetry install --with dev` for development purposes, e.g., any testing etc. (this is also reflected in the [README.md](README.md#development)).