### PR TITLE
Outsource `StatisticsMixin` interface from `taskmodules.common.RelationStatisticsMixin`

### DIFF
--- a/src/pie_modules/taskmodules/common/__init__.py
+++ b/src/pie_modules/taskmodules/common/__init__.py
@@ -1,4 +1,4 @@
 from .interfaces import AnnotationEncoderDecoder, DecodingException
-from .mixins import BatchableMixin
+from .mixins import BatchableMixin, RelationStatisticsMixin, StatisticsMixin
 from .taskmodule_with_document_converter import TaskModuleWithDocumentConverter
 from .utils import get_first_occurrence_index

--- a/src/pie_modules/taskmodules/common/mixins.py
+++ b/src/pie_modules/taskmodules/common/mixins.py
@@ -260,7 +260,8 @@ class RelationStatisticsMixin(StatisticsMixin[Dict[str, int]]):
         to_show = pd.Series(statistics)
         if len(to_show.index.names) > 1:
             to_show = to_show.unstack()
-        to_show = to_show.fillna(0)
+        # fill missing values with 0 and convert back to int (unstacking may introduce NaNs which are float type)
+        to_show = to_show.fillna(0).astype(int)
         if to_show.columns.size > 1:
             # TODO: "no_relation" should be "parameterized" (not trivial, because that parameter
             #  is defined in the taskmodule, e.g, none_label for RETextClassificationWithIndicesTaskModule)

--- a/src/pie_modules/taskmodules/common/mixins.py
+++ b/src/pie_modules/taskmodules/common/mixins.py
@@ -243,7 +243,8 @@ class RelationStatisticsMixin(StatisticsMixin[Dict[str, int]]):
                 else:
                     raise ValueError(f"unknown key: {key}")
                 for rel in rels_set:
-                    # TODO: "no_relation" should be parameterized
+                    # TODO: "no_relation" should be "parameterized" (not trivial, because that parameter
+                    #  is defined in the taskmodule, e.g, none_label for RETextClassificationWithIndicesTaskModule)
                     # Set "no_relation" as label when the score is zero. We encode negative relations
                     # in such a way in the case of multi-label or binary (similarity for coref).
                     label = rel.label if rel.score > 0 else "no_relation"
@@ -261,7 +262,8 @@ class RelationStatisticsMixin(StatisticsMixin[Dict[str, int]]):
             to_show = to_show.unstack()
         to_show = to_show.fillna(0)
         if to_show.columns.size > 1:
-            # TODO: "no_relation" should be parameterized
+            # TODO: "no_relation" should be "parameterized" (not trivial, because that parameter
+            #  is defined in the taskmodule, e.g, none_label for RETextClassificationWithIndicesTaskModule)
             to_show["all_relations"] = to_show.loc[:, to_show.columns != "no_relation"].sum(axis=1)
         if "used" in to_show.index and "available" in to_show.index:
             to_show.loc["used %"] = (100 * to_show.loc["used"] / to_show.loc["available"]).round()

--- a/src/pie_modules/taskmodules/common/mixins.py
+++ b/src/pie_modules/taskmodules/common/mixins.py
@@ -2,7 +2,6 @@ import dataclasses
 import logging
 from abc import ABC, abstractmethod
 from collections import defaultdict
-from copy import deepcopy
 from typing import Any, Dict, Generic, Iterable, List, Optional, Tuple, TypeVar
 
 import pandas as pd

--- a/src/pie_modules/taskmodules/common/mixins.py
+++ b/src/pie_modules/taskmodules/common/mixins.py
@@ -267,7 +267,9 @@ class RelationStatisticsMixin(StatisticsMixin[Dict[Tuple[str, str], int]]):
             #  is defined in the taskmodule, e.g, none_label for RETextClassificationWithIndicesTaskModule)
             to_show["all_relations"] = to_show.loc[:, to_show.columns != "no_relation"].sum(axis=1)
 
-        # TODO: transpose to have the labels (which may be a lot) as index and allow to keep counts as int columns
+        # TODO: transpose
+        #  to have the labels (which may be a lot) as index for improved readability and
+        #  to allow to keep counts as int columns (dtypes are per-column, not per-row)
         if "used" in to_show.index and "available" in to_show.index:
             to_show.loc["used %"] = (100 * to_show.loc["used"] / to_show.loc["available"]).round()
 

--- a/src/pie_modules/taskmodules/common/mixins.py
+++ b/src/pie_modules/taskmodules/common/mixins.py
@@ -160,9 +160,10 @@ class StatisticsMixin(ABC, Generic[T]):
     """A mixin class that provides methods to collect and format statistics.
 
     Args:
-        collect_statistics: Whether to collect statistics or not. If `False`,
-            the mixin will not collect any statistics and the `get_statistics`
-            method will return an empty dictionary.
+        collect_statistics: Control whether statistics should be collected.
+            If `False`, the mixin will not show any statistics when calling
+            `show_statistics`. Further effects depend on the implementation
+            of the mixin.
         **kwargs: Additional keyword arguments to pass to the parent class.
     """
 
@@ -199,6 +200,14 @@ class StatisticsMixin(ABC, Generic[T]):
 
 
 class RelationStatisticsMixin(StatisticsMixin[Dict[str, int]]):
+    """A mixin class that provides methods to collect and format statistics about relations. This
+    mixin collects statistics about relations, such as the number of available, used, and skipped
+    relations.
+
+    Args:
+        collect_statistics: Whether to collect statistics or not. If `False`, the mixin will not
+            collect any statistics and the `get_statistics` method will return an empty dictionary.
+    """
 
     def reset_statistics(self):
         self._statistics = defaultdict(int)
@@ -234,6 +243,7 @@ class RelationStatisticsMixin(StatisticsMixin[Dict[str, int]]):
                 else:
                     raise ValueError(f"unknown key: {key}")
                 for rel in rels_set:
+                    # TODO: "no_relation" should be parameterized
                     # Set "no_relation" as label when the score is zero. We encode negative relations
                     # in such a way in the case of multi-label or binary (similarity for coref).
                     label = rel.label if rel.score > 0 else "no_relation"
@@ -251,6 +261,7 @@ class RelationStatisticsMixin(StatisticsMixin[Dict[str, int]]):
             to_show = to_show.unstack()
         to_show = to_show.fillna(0)
         if to_show.columns.size > 1:
+            # TODO: "no_relation" should be parameterized
             to_show["all_relations"] = to_show.loc[:, to_show.columns != "no_relation"].sum(axis=1)
         if "used" in to_show.index and "available" in to_show.index:
             to_show.loc["used %"] = (100 * to_show.loc["used"] / to_show.loc["available"]).round()

--- a/src/pie_modules/taskmodules/common/mixins.py
+++ b/src/pie_modules/taskmodules/common/mixins.py
@@ -266,6 +266,8 @@ class RelationStatisticsMixin(StatisticsMixin[Dict[Tuple[str, str], int]]):
             # TODO: "no_relation" should be "parameterized" (not trivial, because that parameter
             #  is defined in the taskmodule, e.g, none_label for RETextClassificationWithIndicesTaskModule)
             to_show["all_relations"] = to_show.loc[:, to_show.columns != "no_relation"].sum(axis=1)
+
+        # TODO: transpose to have the labels (which may be a lot) as index and allow to keep counts as int columns
         if "used" in to_show.index and "available" in to_show.index:
             to_show.loc["used %"] = (100 * to_show.loc["used"] / to_show.loc["available"]).round()
 

--- a/src/pie_modules/taskmodules/common/mixins.py
+++ b/src/pie_modules/taskmodules/common/mixins.py
@@ -173,14 +173,15 @@ class StatisticsMixin(ABC, Generic[T]):
 
     @abstractmethod
     def reset_statistics(self):
-        """Reset the statistics collected by this mixin."""
+        """Reset the statistics collected by this mixin (state)."""
         pass
 
     @abstractmethod
     def get_statistics(self) -> T:
         """Get the statistics collected by this mixin.
 
-        May do some finalization if needed.
+        This should *not* modify the state of the mixin, repeated calls should return the same
+        result!
         """
         pass
 

--- a/src/pie_modules/taskmodules/common/mixins.py
+++ b/src/pie_modules/taskmodules/common/mixins.py
@@ -209,9 +209,10 @@ class StatisticsMixin(ABC, Generic[T]):
 
 
 class RelationStatisticsMixin(StatisticsMixin[Dict[Tuple[str, str], int]]):
-    """A mixin class that provides methods to collect and format statistics about relations. This
-    mixin collects statistics about relations, such as the number of available, used, and skipped
-    relations.
+    """A mixin class that provides methods to collect and format statistics about relations.
+
+    This mixin collects statistics about relations, such as the number of available, used, and
+    skipped relations.
     """
 
     def reset_statistics(self):

--- a/src/pie_modules/taskmodules/re_text_classification_with_indices.py
+++ b/src/pie_modules/taskmodules/re_text_classification_with_indices.py
@@ -580,7 +580,7 @@ class RETextClassificationWithIndicesTaskModule(
                             f"relation (with label {prev_label}) for these arguments"
                         )
                         if self.collect_statistics:
-                            self.increase_counter(("skipped_reversed_same_arguments", rel.label))
+                            self.collect_relation("skipped_reversed_same_arguments", reversed_rel)
                         continue
                     elif rel.label in self.symmetric_relations:
                         # warn if the original relation arguments were not sorted by their start and end positions
@@ -605,8 +605,8 @@ class RETextClassificationWithIndicesTaskModule(
                                 f"relations on your own and then setting *reverse_symmetric_relations* to False."
                             )
                             if self.collect_statistics:
-                                self.increase_counter(
-                                    ("used_not_sorted_reversed_arguments", rel.label)
+                                self.collect_relation(
+                                    "used_not_sorted_reversed_arguments", reversed_rel
                                 )
 
                     arguments2relation[reversed_arguments] = reversed_rel

--- a/tests/taskmodules/common/test_mixins.py
+++ b/tests/taskmodules/common/test_mixins.py
@@ -37,12 +37,10 @@ def test_batchable_mixin():
 def test_relation_statistics_mixin_show_statistics(caplog):
     """Test the RelationStatisticsMixin class."""
 
-    @dataclasses.dataclass
     class Foo(RelationStatisticsMixin):
         """A class that uses the RelationStatisticsMixin class."""
 
-        def __init__(self, *args, **kwargs):
-            super().__init__(*args, **kwargs)
+        pass
 
     @dataclasses.dataclass(eq=True, frozen=True)
     class TestAnnotation(Annotation):
@@ -52,17 +50,13 @@ def test_relation_statistics_mixin_show_statistics(caplog):
     x = Foo(collect_statistics=True)
 
     relations = [
-        TestAnnotation(label="A", score=1),
-        TestAnnotation(label="B", score=0.5),
-        TestAnnotation(label="C", score=0.3),
+        TestAnnotation(label="A"),
+        TestAnnotation(label="B"),
+        TestAnnotation(label="C"),
     ]
     x.collect_all_relations(kind="available", relations=relations)
     x.collect_relation(kind="skipped_test", relation=relations[1])
-    x.collect_all_relations(
-        kind="used",
-        relations=set(x._collected_relations["available"])
-        - set(x._collected_relations["skipped_test"]),
-    )
+    x.collect_all_relations(kind="used", relations=[relations[0], relations[2]])
     with caplog.at_level(logging.INFO):
         x.show_statistics()
     assert caplog.messages[0] == (

--- a/tests/taskmodules/common/test_mixins.py
+++ b/tests/taskmodules/common/test_mixins.py
@@ -1,9 +1,12 @@
 import dataclasses
+import logging
 from typing import List
 
 import torch
+from pytorch_ie import Annotation
 
 from pie_modules.taskmodules.common import BatchableMixin
+from pie_modules.taskmodules.common.mixins import RelationStatisticsMixin
 
 
 def test_batchable_mixin():
@@ -29,3 +32,45 @@ def test_batchable_mixin():
     )
     torch.testing.assert_close(batch["a"], torch.tensor([[1, 2, 3], [4, 5, 0]]))
     torch.testing.assert_close(batch["len_a"], torch.tensor([3, 2]))
+
+
+def test_relation_statistics_mixin_show_statistics(caplog):
+    """Test the RelationStatisticsMixin class."""
+
+    @dataclasses.dataclass
+    class Foo(RelationStatisticsMixin):
+        """A class that uses the RelationStatisticsMixin class."""
+
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+
+    @dataclasses.dataclass(eq=True, frozen=True)
+    class TestAnnotation(Annotation):
+        label: str
+        score: float = dataclasses.field(default=1.0, compare=False)
+
+    x = Foo(collect_statistics=True)
+
+    relations = [
+        TestAnnotation(label="A", score=1),
+        TestAnnotation(label="B", score=0.5),
+        TestAnnotation(label="C", score=0.3),
+    ]
+    x.collect_all_relations(kind="available", relations=relations)
+    x.collect_relation(kind="skipped_test", relation=relations[1])
+    x.collect_all_relations(
+        kind="used",
+        relations=set(x._collected_relations["available"])
+        - set(x._collected_relations["skipped_test"]),
+    )
+    with caplog.at_level(logging.INFO):
+        x.show_statistics()
+    assert caplog.messages[0] == (
+        "statistics:\n"
+        "|              |   A |   B |   C |   all_relations |\n"
+        "|:-------------|----:|----:|----:|----------------:|\n"
+        "| available    |   1 |   1 |   1 |               3 |\n"
+        "| skipped_test |   0 |   1 |   0 |               1 |\n"
+        "| used         |   1 |   0 |   1 |               2 |\n"
+        "| used %       | 100 |   0 | 100 |              67 |"
+    )

--- a/tests/taskmodules/common/test_mixins.py
+++ b/tests/taskmodules/common/test_mixins.py
@@ -55,9 +55,13 @@ def test_relation_statistics_mixin_show_statistics(caplog):
         TestAnnotation(label="C"),
         TestAnnotation(label="D"),
     ]
+    # all available relations
     x.collect_all_relations(kind="available", relations=relations)
+    # relations skipped for a reason ("test")
     x.collect_relation(kind="skipped_test", relation=relations[1])
+    # mark two relations as used, one of them is skipped for another (unknown) reason
     x.collect_all_relations(kind="used", relations=[relations[0], relations[2]])
+
     with caplog.at_level(logging.INFO):
         x.show_statistics()
     assert caplog.messages[0] == (

--- a/tests/taskmodules/common/test_mixins.py
+++ b/tests/taskmodules/common/test_mixins.py
@@ -53,6 +53,7 @@ def test_relation_statistics_mixin_show_statistics(caplog):
         TestAnnotation(label="A"),
         TestAnnotation(label="B"),
         TestAnnotation(label="C"),
+        TestAnnotation(label="D"),
     ]
     x.collect_all_relations(kind="available", relations=relations)
     x.collect_relation(kind="skipped_test", relation=relations[1])
@@ -61,10 +62,11 @@ def test_relation_statistics_mixin_show_statistics(caplog):
         x.show_statistics()
     assert caplog.messages[0] == (
         "statistics:\n"
-        "|              |   A |   B |   C |   all_relations |\n"
-        "|:-------------|----:|----:|----:|----------------:|\n"
-        "| available    |   1 |   1 |   1 |               3 |\n"
-        "| skipped_test |   0 |   1 |   0 |               1 |\n"
-        "| used         |   1 |   0 |   1 |               2 |\n"
-        "| used %       | 100 |   0 | 100 |              67 |"
+        "|               |   A |   B |   C |   D |   all_relations |\n"
+        "|:--------------|----:|----:|----:|----:|----------------:|\n"
+        "| available     |   1 |   1 |   1 |   1 |               4 |\n"
+        "| skipped_other |   0 |   0 |   0 |   1 |               1 |\n"
+        "| skipped_test  |   0 |   1 |   0 |   0 |               1 |\n"
+        "| used          |   1 |   0 |   1 |   0 |               2 |\n"
+        "| used %        | 100 |   0 | 100 |   0 |              50 |"
     )


### PR DESCRIPTION
This PR implements the `taskmodules.common.StatisticsMixin` interface, outsourced from `taskmodules.common.RelationStatisticsMixin`. This allows for sth like this in the *training code*:

```python
from pie_modules.taskmodules.common import StatisticsMixin

# e.g. save the statistics in log_hyperparameters() with the logger(s):

...

if isinstance(taskmodule, StatisticsMixin):
    encoding_stats = taskmodule.get_statistics()
    # add the values to the hparams (prefixed), similar to saving number of model parameters
    if isinstance(encoding_stats, dict):
        for k, v in encoding_stats.items():
            hparams[f"{key_prefix}encoding_statistics/{k}"] = v
    else:
        raise ValueError("encoding statistics returned by the taskmodule have unexpected format")

# as before
if model is not None:
   ...
```
and than calling this directly after calling `trainer.fit`:
```python
utils.log_hyperparameters(logger=logger, taskmodule=taskmodule)
```

Notes: This also
- adds an improved version of `test_relation_statistics_mixin_show_statistics` taken from #191.
- removes `RelationStatisticsMixin.increase_counter` to reduce the interface. This is used only in `RETextClassificationWithIndicesTaskModule` which is adjusted accordingly, that's why this is *not* marked as breaking.
- adds some TODOs, but they should be handled in follow-up PRs  

Context: #197.