### PR TITLE
Fix `PrefixConstrainedLogitsProcessorWithMaximum` (+/-inf scores)

### DIFF
--- a/src/pie_modules/taskmodules/pointer_network/logits_processor.py
+++ b/src/pie_modules/taskmodules/pointer_network/logits_processor.py
@@ -12,11 +12,9 @@ class PrefixConstrainedLogitsProcessorWithMaximum(LogitsProcessor):
     can be an index into the input which depends on the length of that input.
 
     Args:
-        prefix_allowed_tokens_fn (`Callable[[int, torch.Tensor, int], List[int]]`):
-            This function constraints the beam search to allowed tokens only at each step. This function takes 2
-            arguments `inputs_ids` and the batch ID `batch_id`. It has to return a list with the allowed tokens for the
-            next generation step conditioned on the previously generated tokens `inputs_ids` and the batch ID
-            `batch_id`.
+        prefix_allowed_tokens_fn (Callable[[int, torch.LongTensor, int], List[int]]):
+            Should return the list of token ids allowed at the next generation step,
+            given (`batch_id`, `input_ids_so_far`, `max_index`).
     """
 
     def __init__(
@@ -31,6 +29,12 @@ class PrefixConstrainedLogitsProcessorWithMaximum(LogitsProcessor):
     def __call__(
         self, input_ids: torch.LongTensor, scores: torch.FloatTensor
     ) -> torch.FloatTensor:
+        if not torch.isfinite(scores).all():
+            raise ValueError(
+                "scores contains ±inf or NaN, which is not allowed by "
+                "PrefixConstrainedLogitsProcessorWithMaximum. "
+                "Insert FinitizeLogitsProcessor earlier to clean them."
+            )
         mask = torch.full_like(scores, -math.inf)
         for batch_id, beam_sent in enumerate(
             input_ids.view(-1, self._num_beams, input_ids.shape[-1])

--- a/src/pie_modules/taskmodules/pointer_network_for_end2end_re.py
+++ b/src/pie_modules/taskmodules/pointer_network_for_end2end_re.py
@@ -244,7 +244,7 @@ class PointerNetworkTaskModuleForEnd2EndRE(
         if self.constrained_generation:
             logits_processor = LogitsProcessorList()
             # PrefixConstrainedLogitsProcessorWithMaximum requires finite logits
-            logits_processor.append(FinitizeLogitsProcessor)
+            logits_processor.append(FinitizeLogitsProcessor())
             logits_processor.append(
                 PrefixConstrainedLogitsProcessorWithMaximum(
                     prefix_allowed_tokens_fn=self._prefix_allowed_tokens_fn_with_maximum,

--- a/src/pie_modules/taskmodules/pointer_network_for_end2end_re.py
+++ b/src/pie_modules/taskmodules/pointer_network_for_end2end_re.py
@@ -58,6 +58,7 @@ from .pointer_network.annotation_encoder_decoder import (
     SpanEncoderDecoderWithOffset,
 )
 from .pointer_network.logits_processor import (
+    FinitizeLogitsProcessor,
     PrefixConstrainedLogitsProcessorWithMaximum,
 )
 
@@ -242,6 +243,8 @@ class PointerNetworkTaskModuleForEnd2EndRE(
         result: Dict[str, Any] = {"no_repeat_ngram_size": 7}
         if self.constrained_generation:
             logits_processor = LogitsProcessorList()
+            # PrefixConstrainedLogitsProcessorWithMaximum requires finite logits
+            logits_processor.append(FinitizeLogitsProcessor)
             logits_processor.append(
                 PrefixConstrainedLogitsProcessorWithMaximum(
                     prefix_allowed_tokens_fn=self._prefix_allowed_tokens_fn_with_maximum,

--- a/tests/taskmodules/pointer_network/test_logits_processor.py
+++ b/tests/taskmodules/pointer_network/test_logits_processor.py
@@ -49,6 +49,21 @@ def test_prefix_constrained_logits_processor_with_maximum_with_inf_scores():
         logits_processor(input_ids, scores_with_neg_inf)
 
 
+def test_prefix_constrained_logits_processor_with_maximum_without_allowed_tokens():
+    def allow_no_tokens(batch_id, sent, max_index):
+        return []
+
+    logits_processor = PrefixConstrainedLogitsProcessorWithMaximum(
+        prefix_allowed_tokens_fn=allow_no_tokens, num_beams=1
+    )
+
+    input_ids = torch.tensor([[1, 2, 3, 4, 5, 6, 7]]).to(dtype=torch.long)
+    scores = torch.tensor([[0.9, 0.9, 0.9, 0.9, 0.9, 0.9, 0.0]]).to(dtype=torch.float)
+
+    with pytest.raises(ValueError, match="No allowed token ids for batch_id"):
+        logits_processor(input_ids, scores)
+
+
 def test_finitize_logits_processor():
     logits_processor = FinitizeLogitsProcessor()
 

--- a/tests/taskmodules/test_pointer_network_for_end2end_re.py
+++ b/tests/taskmodules/test_pointer_network_for_end2end_re.py
@@ -12,6 +12,7 @@ from pie_modules.annotations import BinaryRelation, LabeledSpan
 from pie_modules.documents import TextBasedDocument
 from pie_modules.taskmodules import PointerNetworkTaskModuleForEnd2EndRE
 from pie_modules.taskmodules.pointer_network.logits_processor import (
+    FinitizeLogitsProcessor,
     PrefixConstrainedLogitsProcessorWithMaximum,
 )
 from pie_modules.taskmodules.pointer_network_for_end2end_re import (
@@ -1189,7 +1190,8 @@ def test_configure_model_generation_with_constrained_generation():
     assert generation_config["no_repeat_ngram_size"] == 7
     logits_processor = generation_config["logits_processor"]
     assert isinstance(logits_processor, LogitsProcessorList)
-    assert len(logits_processor) == 1
+    assert len(logits_processor) == 2
+    assert isinstance(logits_processor[0], FinitizeLogitsProcessor)
     assert isinstance(logits_processor[0], PrefixConstrainedLogitsProcessorWithMaximum)
 
 

--- a/tests/taskmodules/test_pointer_network_for_end2end_re.py
+++ b/tests/taskmodules/test_pointer_network_for_end2end_re.py
@@ -1192,7 +1192,7 @@ def test_configure_model_generation_with_constrained_generation():
     assert isinstance(logits_processor, LogitsProcessorList)
     assert len(logits_processor) == 2
     assert isinstance(logits_processor[0], FinitizeLogitsProcessor)
-    assert isinstance(logits_processor[0], PrefixConstrainedLogitsProcessorWithMaximum)
+    assert isinstance(logits_processor[1], PrefixConstrainedLogitsProcessorWithMaximum)
 
 
 def test_prefix_allowed_tokens_fn_with_maximum():


### PR DESCRIPTION
If the scores calculated by the model contain +/-infinitive values, the masking in `PrefixConstrainedLogitsProcessorWithMaximum` does not work correctly because it masks by adding `-inf` to all token id entries that are not allowed. This results in sometimes producing the not allowed ids very early in the training which can cause problems for other code (e.g., parsing) that assumes a certain token id "format". In theory, the behavior may be also strange when scores contains `+inf` values (how is `-inf + inf` defined?), but i did not observe this yet in practice.

With this PR, we do three things:
1. in `PrefixConstrainedLogitsProcessorWithMaximum`: raise an error if `scores` contains `+/-inf` values
2. implement `FinitizeLogitsProcessor`: Replaces any `±inf` logits with the largest-magnitude finite values for the tensor’s dtype, ensuring all logits are valid for downstream ops. 
3. fix the pointer network taskmodule: add a `FinitizeLogitsProcessor` to the beginning of the `logits_processor` list (ie.e, before `PrefixConstrainedLogitsProcessorWithMaximum`) in `PointerNetworkTaskModuleForEnd2EndRE.configure_model_generation`  