### PR TITLE
`BinaryRelationEncoderDecoder.parse`: never return `remaining`s that are longer than 6

### DIFF
--- a/src/pie_modules/taskmodules/pointer_network/annotation_encoder_decoder.py
+++ b/src/pie_modules/taskmodules/pointer_network/annotation_encoder_decoder.py
@@ -381,8 +381,10 @@ class BinaryRelationEncoderDecoder(AnnotationEncoderDecoder[BinaryRelation, List
         if len(encoding):
             for i in encoding:
                 current_encoding.append(i)
-                # An encoding is complete when it ends with a relation_id
-                # or when it has a length of 7
+                # An encoding is complete when it ends with a relation_id or when it has
+                # a length of 7, encodings with length above 7 are never valid. Note that
+                # all incomplete encodings (the 3rd return value of this method) need to
+                # be processable by build_decoding_constraints!
                 if i in relation_ids or len(current_encoding) == 7:
                     # try to decode the current relation encoding
                     try:

--- a/src/pie_modules/taskmodules/pointer_network/annotation_encoder_decoder.py
+++ b/src/pie_modules/taskmodules/pointer_network/annotation_encoder_decoder.py
@@ -382,8 +382,8 @@ class BinaryRelationEncoderDecoder(AnnotationEncoderDecoder[BinaryRelation, List
             for i in encoding:
                 current_encoding.append(i)
                 # An encoding is complete when it ends with a relation_id
-                # or when it contains a none_id and has a length of 7
-                if i in relation_ids or (i == none_id and len(current_encoding) == 7):
+                # or when it has a length of 7
+                if i in relation_ids or len(current_encoding) == 7:
                     # try to decode the current relation encoding
                     try:
                         valid_encoding = self.decode(encoding=current_encoding)


### PR DESCRIPTION
Despite having #199 now, it still happens that token sequences get produced that are not allowed which breaks follow-up code of parsing which expects that everything that did not got parsed (a.k.a. the `remaining` sequence) is shorter than a complete tuple, i.e., 7 entries. Thus, we enforce the `remaining` to be shorter than 7 tokens directly in the parse method by trying to decode all chunks that grow up to 7 entries (instead of requiring that they also end with a `none_label`).

EDIT: ~~Thinking about this again, it may be more correct to adjust the `BinaryRelationEncoderDecoder.build_decoding_constraints` to work with `partial_encoding` of `length >= 7`.~~ This needs further investigation why this happens at all.

TODO: 
- [ ] decide if the approach mentioned as EDIT would be better
- [ ] test in downstream projects