### PR TITLE
add `none_label` parameter to `RelationStatisticsMixin`

### DIFF
--- a/src/pie_modules/taskmodules/common/mixins.py
+++ b/src/pie_modules/taskmodules/common/mixins.py
@@ -223,7 +223,9 @@ class RelationStatisticsMixin(StatisticsMixin[Dict[Tuple[str, str], int]]):
                 self._statistics_none_label = "no_relation"
                 logger.warning(
                     f"{type(self).__name__} does not have a `none_label` attribute. "
-                    "Using 'no_relation' as the label for relations with score 0."
+                    "Using 'no_relation' as the label for relations with score 0 in statistics. "
+                    f"Set the `none_label` or `_statistics_none_label` attribute before using statistics or "
+                    f"overwrite `get_none_label_for_statistics()` function to get rid of this message."
                 )
 
         return self._statistics_none_label

--- a/src/pie_modules/taskmodules/common/mixins.py
+++ b/src/pie_modules/taskmodules/common/mixins.py
@@ -215,8 +215,9 @@ class RelationStatisticsMixin(StatisticsMixin[Dict[Tuple[str, str], int]]):
     """
 
     def __init__(self, none_label: str = "no_relation", **kwargs):
-        self.none_label = none_label
         super().__init__(**kwargs)
+        if not hasattr(self, "none_label"):
+            self.none_label = none_label
 
     def reset_statistics(self):
         self._collected_relations: Dict[str, List[Annotation]] = defaultdict(list)

--- a/src/pie_modules/taskmodules/common/mixins.py
+++ b/src/pie_modules/taskmodules/common/mixins.py
@@ -226,8 +226,8 @@ class RelationStatisticsMixin(StatisticsMixin[Dict[Tuple[str, str], int]]):
                     "Using default value 'no_relation'. "
                     "`none_label` is used as the label for relations with score 0 in statistics and "
                     "all relations with label different from `none_label` will be summarized to 'all_relations'. "
-                    f"Set the `none_label` or `_statistics_none_label` attribute before using statistics or "
-                    f"overwrite `get_none_label_for_statistics()` function to get rid of this message."
+                    "Set the `none_label` attribute before using statistics or "
+                    "overwrite `get_none_label_for_statistics()` function to get rid of this message."
                 )
 
         return self._statistics_none_label

--- a/src/pie_modules/taskmodules/common/mixins.py
+++ b/src/pie_modules/taskmodules/common/mixins.py
@@ -223,7 +223,9 @@ class RelationStatisticsMixin(StatisticsMixin[Dict[Tuple[str, str], int]]):
                 self._statistics_none_label = "no_relation"
                 logger.warning(
                     f"{type(self).__name__} does not have a `none_label` attribute. "
-                    "Using 'no_relation' as the label for relations with score 0 in statistics. "
+                    "Using default value 'no_relation'. "
+                    "`none_label` is used as the label for relations with score 0 in statistics and "
+                    "all relations with label different from `none_label` will be summarized to 'all_relations'. "
                     f"Set the `none_label` or `_statistics_none_label` attribute before using statistics or "
                     f"overwrite `get_none_label_for_statistics()` function to get rid of this message."
                 )

--- a/tests/taskmodules/common/test_mixins.py
+++ b/tests/taskmodules/common/test_mixins.py
@@ -65,7 +65,7 @@ def test_relation_statistics_mixin_show_statistics(caplog):
     with caplog.at_level(logging.INFO):
         x.show_statistics()
     assert caplog.messages[0] == (
-        "Foo does not have a `none_label` attribute. Using 'no_relation' as the label for relations with score 0."
+        "Foo does not have a `none_label` attribute. Using 'no_relation' as the label for relations with score 0 in statistics. Set the `none_label` or `_statistics_none_label` attribute before using statistics or overwrite `get_none_label_for_statistics()` function to get rid of this message."
     )
     assert caplog.messages[1] == (
         "statistics:\n"
@@ -80,7 +80,7 @@ def test_relation_statistics_mixin_show_statistics(caplog):
 
 
 def test_relation_statistics_mixin_show_statistics_no_relations(caplog):
-    """Test the RelationStatisticsMixin class."""
+    """Test the RelationStatisticsMixin class with 0 score prediction."""
 
     class Foo(RelationStatisticsMixin):
         """A class that uses the RelationStatisticsMixin class."""
@@ -97,13 +97,13 @@ def test_relation_statistics_mixin_show_statistics_no_relations(caplog):
     assert caplog.messages[0] == "statistics:\n" "| 0   |\n" "|-----|"
 
 
-def test_relation_statistics_mixin_show_statistics_custom_none_relation(caplog):
-    """Test the RelationStatisticsMixin class."""
+def test_relation_statistics_mixin_show_statistics_custom_none_label(caplog):
+    """Test the RelationStatisticsMixin class with custom none_label."""
 
     class Foo(RelationStatisticsMixin):
         """A class that uses the RelationStatisticsMixin class.
 
-        It also consumes none_label parameter to show it still works.
+        It also sets the `none_label` attribute which will be used by statistics.
         """
 
         def __init__(self, none_label: str = "no_relation", **kwargs):

--- a/tests/taskmodules/common/test_mixins.py
+++ b/tests/taskmodules/common/test_mixins.py
@@ -65,7 +65,10 @@ def test_relation_statistics_mixin_show_statistics(caplog):
     with caplog.at_level(logging.INFO):
         x.show_statistics()
     assert caplog.messages[0] == (
-        "Foo does not have a `none_label` attribute. Using 'no_relation' as the label for relations with score 0 in statistics. Set the `none_label` or `_statistics_none_label` attribute before using statistics or overwrite `get_none_label_for_statistics()` function to get rid of this message."
+        "Foo does not have a `none_label` attribute. "
+        "Using 'no_relation' as the label for relations with score 0 in statistics. "
+        "Set the `none_label` or `_statistics_none_label` attribute before using statistics or "
+        "overwrite `get_none_label_for_statistics()` function to get rid of this message."
     )
     assert caplog.messages[1] == (
         "statistics:\n"

--- a/tests/taskmodules/common/test_mixins.py
+++ b/tests/taskmodules/common/test_mixins.py
@@ -79,7 +79,9 @@ def test_relation_statistics_mixin_show_statistics(caplog):
         x.show_statistics()
     assert caplog.messages[0] == (
         "Foo does not have a `none_label` attribute. "
-        "Using 'no_relation' as the label for relations with score 0 in statistics. "
+        "Using default value 'no_relation'. "
+        "`none_label` is used as the label for relations with score 0 in statistics and "
+        "all relations with label different from `none_label` will be summarized to 'all_relations'. "
         "Set the `none_label` or `_statistics_none_label` attribute before using statistics or "
         "overwrite `get_none_label_for_statistics()` function to get rid of this message."
     )

--- a/tests/taskmodules/common/test_mixins.py
+++ b/tests/taskmodules/common/test_mixins.py
@@ -50,10 +50,10 @@ def test_relation_statistics_mixin_show_statistics(caplog):
     x = Foo(collect_statistics=True)
 
     relations = [
-        TestAnnotation(label="A"),
-        TestAnnotation(label="B"),
-        TestAnnotation(label="C"),
-        TestAnnotation(label="D"),
+        TestAnnotation(label="A", score=1.0),
+        TestAnnotation(label="B", score=0.5),
+        TestAnnotation(label="C", score=0.0),
+        TestAnnotation(label="D", score=0.3),
     ]
     # all available relations
     x.collect_all_relations(kind="available", relations=relations)
@@ -67,12 +67,12 @@ def test_relation_statistics_mixin_show_statistics(caplog):
     assert statistics == {
         ("available", "A"): 1,
         ("available", "B"): 1,
-        ("available", "C"): 1,
         ("available", "D"): 1,
+        ("available", "no_relation"): 1,
         ("skipped_other", "D"): 1,
         ("skipped_test", "B"): 1,
         ("used", "A"): 1,
-        ("used", "C"): 1,
+        ("used", "no_relation"): 1,
     }
 
     with caplog.at_level(logging.INFO):
@@ -89,9 +89,9 @@ def test_relation_statistics_mixin_show_statistics(caplog):
         "|:--------------|------------:|----------------:|---------------:|-------:|---------:|\n"
         "| A             |           1 |               0 |              0 |      1 |      100 |\n"
         "| B             |           1 |               0 |              1 |      0 |        0 |\n"
-        "| C             |           1 |               0 |              0 |      1 |      100 |\n"
         "| D             |           1 |               1 |              0 |      0 |        0 |\n"
-        "| all_relations |           4 |               1 |              1 |      2 |       50 |"
+        "| no_relation   |           1 |               0 |              0 |      1 |      100 |\n"
+        "| all_relations |           3 |               1 |              1 |      1 |       33 |"
     )
 
 

--- a/tests/taskmodules/common/test_mixins.py
+++ b/tests/taskmodules/common/test_mixins.py
@@ -96,7 +96,7 @@ def test_relation_statistics_mixin_show_statistics(caplog):
 
 
 def test_relation_statistics_mixin_show_statistics_no_relations(caplog):
-    """Test the RelationStatisticsMixin class with 0 score prediction."""
+    """Test the RelationStatisticsMixin class with no predictions."""
 
     class Foo(RelationStatisticsMixin):
         """A class that uses the RelationStatisticsMixin class."""

--- a/tests/taskmodules/common/test_mixins.py
+++ b/tests/taskmodules/common/test_mixins.py
@@ -12,7 +12,6 @@ from pie_modules.taskmodules.common.mixins import RelationStatisticsMixin
 def test_batchable_mixin():
     """Test the BatchableMixin class."""
 
-    # pylint: disable=too-few-public-methods
     @dataclasses.dataclass
     class Foo(BatchableMixin):
         """A class that uses the BatchableMixin class."""

--- a/tests/taskmodules/common/test_mixins.py
+++ b/tests/taskmodules/common/test_mixins.py
@@ -81,7 +81,7 @@ def test_relation_statistics_mixin_show_statistics(caplog):
         "Using default value 'no_relation'. "
         "`none_label` is used as the label for relations with score 0 in statistics and "
         "all relations with label different from `none_label` will be summarized to 'all_relations'. "
-        "Set the `none_label` or `_statistics_none_label` attribute before using statistics or "
+        "Set the `none_label` attribute before using statistics or "
         "overwrite `get_none_label_for_statistics()` function to get rid of this message."
     )
     assert caplog.messages[1] == (

--- a/tests/taskmodules/common/test_mixins.py
+++ b/tests/taskmodules/common/test_mixins.py
@@ -65,6 +65,9 @@ def test_relation_statistics_mixin_show_statistics(caplog):
     with caplog.at_level(logging.INFO):
         x.show_statistics()
     assert caplog.messages[0] == (
+        "Foo does not have a `none_label` attribute. Using 'no_relation' as the label for relations with score 0."
+    )
+    assert caplog.messages[1] == (
         "statistics:\n"
         "|               |   A |   B |   C |   D |   all_relations |\n"
         "|:--------------|----:|----:|----:|----:|----------------:|\n"

--- a/tests/taskmodules/test_cross_text_binary_coref.py
+++ b/tests/taskmodules/test_cross_text_binary_coref.py
@@ -172,7 +172,10 @@ def test_encode_with_collect_statistics(taskmodule, positive_documents, caplog):
     assert len(caplog.messages) == 2
     assert (
         caplog.messages[0]
-        == "CrossTextBinaryCorefTaskModule does not have a `none_label` attribute. Using 'no_relation' as the label for relations with score 0."
+        == "CrossTextBinaryCorefTaskModule does not have a `none_label` attribute. "
+        "Using 'no_relation' as the label for relations with score 0 in statistics. "
+        "Set the `none_label` or `_statistics_none_label` attribute before using statistics or "
+        "overwrite `get_none_label_for_statistics()` function to get rid of this message."
     )
     assert (
         caplog.messages[1] == "statistics:\n"

--- a/tests/taskmodules/test_cross_text_binary_coref.py
+++ b/tests/taskmodules/test_cross_text_binary_coref.py
@@ -169,9 +169,13 @@ def test_encode_with_collect_statistics(taskmodule, positive_documents, caplog):
         taskmodule.encode(documents_with_negatives, encode_target=True)
         taskmodule.collect_statistics = original_values
 
-    assert len(caplog.messages) == 1
+    assert len(caplog.messages) == 2
     assert (
-        caplog.messages[0] == "statistics:\n"
+        caplog.messages[0]
+        == "CrossTextBinaryCorefTaskModule does not have a `none_label` attribute. Using 'no_relation' as the label for relations with score 0."
+    )
+    assert (
+        caplog.messages[1] == "statistics:\n"
         "|           |   coref |   no_relation |   all_relations |\n"
         "|:----------|--------:|--------------:|----------------:|\n"
         "| available |       4 |             6 |               4 |\n"


### PR DESCRIPTION
- `src/pie_modules/taskmodules/common/mixins.py`
  * add a lazy-getter `get_none_label_for_statistics()` to `RelationStatisticsMixin`
- `tests/taskmodules/common/test_mixins.py`
  * update tests

Statistics are now getting `self.none_label` only once, when `none_label` is needed for the first time.
If it was not set - default value is used instead and a warning logged.
Value is saved in `self._statistics_none_label` for further use.