### PR TITLE
transpose statistics in `RelationStatisticsMixin`

### DIFF
--- a/src/pie_modules/taskmodules/common/mixins.py
+++ b/src/pie_modules/taskmodules/common/mixins.py
@@ -271,10 +271,11 @@ class RelationStatisticsMixin(StatisticsMixin[Dict[Tuple[str, str], int]]):
             #  is defined in the taskmodule, e.g, none_label for RETextClassificationWithIndicesTaskModule)
             to_show["all_relations"] = to_show.loc[:, to_show.columns != "no_relation"].sum(axis=1)
 
-        # TODO: transpose
+        #  transpose
         #  to have the labels (which may be a lot) as index for improved readability and
         #  to allow to keep counts as int columns (dtypes are per-column, not per-row)
-        if "used" in to_show.index and "available" in to_show.index:
-            to_show.loc["used %"] = (100 * to_show.loc["used"] / to_show.loc["available"]).round()
+        to_show = to_show.T
+        if "used" in to_show.columns and "available" in to_show.columns:
+            to_show["used %"] = (100 * to_show["used"] / to_show["available"]).round()
 
         return to_show.to_markdown()

--- a/tests/taskmodules/common/test_mixins.py
+++ b/tests/taskmodules/common/test_mixins.py
@@ -62,6 +62,19 @@ def test_relation_statistics_mixin_show_statistics(caplog):
     # mark two relations as used, one of them is skipped for another (unknown) reason
     x.collect_all_relations(kind="used", relations=[relations[0], relations[2]])
 
+    statistics = x.get_statistics()
+
+    assert statistics == {
+        ("available", "A"): 1,
+        ("available", "B"): 1,
+        ("available", "C"): 1,
+        ("available", "D"): 1,
+        ("skipped_other", "D"): 1,
+        ("skipped_test", "B"): 1,
+        ("used", "A"): 1,
+        ("used", "C"): 1,
+    }
+
     with caplog.at_level(logging.INFO):
         x.show_statistics()
     assert caplog.messages[0] == (
@@ -89,6 +102,11 @@ def test_relation_statistics_mixin_show_statistics_no_relations(caplog):
     # Test with no relations collected
     x.collect_all_relations(kind="available", relations=[])
     x.collect_all_relations(kind="used", relations=[])
+
+    statistics = x.get_statistics()
+
+    assert statistics == {}
+
     with caplog.at_level(logging.INFO):
         x.show_statistics()
     assert caplog.messages[0] == ("statistics:\n" "|--:|\n" "| 0 |")

--- a/tests/taskmodules/common/test_mixins.py
+++ b/tests/taskmodules/common/test_mixins.py
@@ -66,13 +66,13 @@ def test_relation_statistics_mixin_show_statistics(caplog):
         x.show_statistics()
     assert caplog.messages[0] == (
         "statistics:\n"
-        "|               |   A |   B |   C |   D |   all_relations |\n"
-        "|:--------------|----:|----:|----:|----:|----------------:|\n"
-        "| available     |   1 |   1 |   1 |   1 |               4 |\n"
-        "| skipped_other |   0 |   0 |   0 |   1 |               1 |\n"
-        "| skipped_test  |   0 |   1 |   0 |   0 |               1 |\n"
-        "| used          |   1 |   0 |   1 |   0 |               2 |\n"
-        "| used %        | 100 |   0 | 100 |   0 |              50 |"
+        "|               |   available |   skipped_other |   skipped_test |   used |   used % |\n"
+        "|:--------------|------------:|----------------:|---------------:|-------:|---------:|\n"
+        "| A             |           1 |               0 |              0 |      1 |      100 |\n"
+        "| B             |           1 |               0 |              1 |      0 |        0 |\n"
+        "| C             |           1 |               0 |              0 |      1 |      100 |\n"
+        "| D             |           1 |               1 |              0 |      0 |        0 |\n"
+        "| all_relations |           4 |               1 |              1 |      2 |       50 |"
     )
 
 
@@ -91,4 +91,4 @@ def test_relation_statistics_mixin_show_statistics_no_relations(caplog):
     x.collect_all_relations(kind="used", relations=[])
     with caplog.at_level(logging.INFO):
         x.show_statistics()
-    assert caplog.messages[0] == ("statistics:\n" "| 0   |\n" "|-----|")
+    assert caplog.messages[0] == ("statistics:\n" "|--:|\n" "| 0 |")

--- a/tests/taskmodules/test_re_text_classification_with_indices.py
+++ b/tests/taskmodules/test_re_text_classification_with_indices.py
@@ -1163,9 +1163,10 @@ def test_encode_input_multiple_relations_for_same_arguments(
                     ("skipped_same_arguments", "per:founder"): 1,
                     ("used", "per:founded_by"): 1,
                 }
+                assert caplog.messages == []
             else:
-                assert len(caplog.messages) == 1
-                assert caplog.messages[0] == expected_warning
+                assert statistics == {}
+                assert caplog.messages == [expected_warning]
 
         else:
             # as above, but with candidate (negative) relations added
@@ -1181,6 +1182,8 @@ def test_encode_input_multiple_relations_for_same_arguments(
                     ("used", "per:founded_by"): 1,
                     ("skipped_same_arguments", "per:founder"): 1,
                 }
+            else:
+                assert statistics == {}
 
     elif handle_relations_with_same_arguments == "keep_none":
         expected_warning = (
@@ -1200,9 +1203,10 @@ def test_encode_input_multiple_relations_for_same_arguments(
                     ("skipped_same_arguments", "per:founder"): 1,
                     ("skipped_same_arguments", "per:founded_by"): 1,
                 }
+                assert caplog.messages == []
             else:
-                assert len(caplog.messages) == 1
-                assert caplog.messages[0] == expected_warning
+                assert statistics == {}
+                assert caplog.messages == [expected_warning]
         else:
             # all conflicting relations go into the same direction, so we can create a candidate (negative)
             # relation for the other direction.
@@ -1215,9 +1219,10 @@ def test_encode_input_multiple_relations_for_same_arguments(
                     ("skipped_same_arguments", "per:founder"): 1,
                     ("used", "no_relation"): 1,
                 }
+                assert caplog.messages == []
             else:
-                assert len(caplog.messages) == 1
-                assert caplog.messages[0] == expected_warning
+                assert statistics == {}
+                assert caplog.messages == [expected_warning]
 
 
 def test_encode_input_handle_relations_with_same_arguments_unknown_value():
@@ -1304,6 +1309,8 @@ def test_encode_input_duplicated_relations(
                 ("used", "no_relation"): 1,
                 ("used", "per:founded_by"): 1,
             }
+        else:
+            assert statistics == {}
     else:
         assert candidate_relation_tuples == [(("PER", "A"), "per:founded_by", ("PER", "B"))]
         if collect_statistics:
@@ -1311,6 +1318,8 @@ def test_encode_input_duplicated_relations(
                 ("available", "per:founded_by"): 1,
                 ("used", "per:founded_by"): 1,
             }
+        else:
+            assert statistics == {}
 
 
 def test_encode_input_argument_role_unknown(documents):

--- a/tests/taskmodules/test_re_text_classification_with_indices.py
+++ b/tests/taskmodules/test_re_text_classification_with_indices.py
@@ -1135,16 +1135,15 @@ def test_encode_input_multiple_relations_for_same_arguments(
     )
     taskmodule.prepare([document])
 
-    encodings = taskmodule.encode_input(document)
+    with caplog.at_level(logging.WARNING):
+        encodings = taskmodule.encode_input(document)
 
-    with caplog.at_level(logging.INFO):
-        taskmodule.show_statistics()
+    statistics = taskmodule.get_statistics()
     candidate_relation = [enc.metadata["candidate_annotation"] for enc in encodings]
     candidate_relation_tuples = [
         (rel.head.resolve(), rel.label, rel.tail.resolve()) for rel in candidate_relation
     ]
 
-    assert len(caplog.messages) == 1
     if handle_relations_with_same_arguments == "keep_first":
         expected_warning = (
             "doc.id=test_doc: there are multiple relations with the same arguments "
@@ -1158,16 +1157,14 @@ def test_encode_input_multiple_relations_for_same_arguments(
             # nor as skipped in statistics.
             assert candidate_relation_tuples == [(("PER", "A"), "per:founded_by", ("PER", "B"))]
             if collect_statistics:
-                assert (
-                    caplog.messages[0] == "statistics:\n"
-                    "|                        |   per:founded_by |   per:founder |   all_relations |\n"
-                    "|:-----------------------|-----------------:|--------------:|----------------:|\n"
-                    "| available              |                1 |             1 |               2 |\n"
-                    "| skipped_same_arguments |                0 |             1 |               1 |\n"
-                    "| used                   |                1 |             0 |               1 |\n"
-                    "| used %                 |              100 |             0 |              50 |"
-                )
+                assert statistics == {
+                    ("available", "per:founded_by"): 1,
+                    ("available", "per:founder"): 1,
+                    ("skipped_same_arguments", "per:founder"): 1,
+                    ("used", "per:founded_by"): 1,
+                }
             else:
+                assert len(caplog.messages) == 1
                 assert caplog.messages[0] == expected_warning
 
         else:
@@ -1177,15 +1174,13 @@ def test_encode_input_multiple_relations_for_same_arguments(
                 (("PER", "B"), "no_relation", ("PER", "A")),
             ]
             if collect_statistics:
-                assert (
-                    caplog.messages[0] == "statistics:\n"
-                    "|                        |   no_relation |   per:founded_by |   per:founder |   all_relations |\n"
-                    "|:-----------------------|--------------:|-----------------:|--------------:|----------------:|\n"
-                    "| available              |             0 |                1 |             1 |               2 |\n"
-                    "| skipped_same_arguments |             0 |                0 |             1 |               1 |\n"
-                    "| used                   |             1 |                1 |             0 |               1 |\n"
-                    "| used %                 |           inf |              100 |             0 |              50 |"
-                )
+                assert statistics == {
+                    ("available", "per:founded_by"): 1,
+                    ("available", "per:founder"): 1,
+                    ("used", "no_relation"): 1,
+                    ("used", "per:founded_by"): 1,
+                    ("skipped_same_arguments", "per:founder"): 1,
+                }
 
     elif handle_relations_with_same_arguments == "keep_none":
         expected_warning = (
@@ -1199,34 +1194,33 @@ def test_encode_input_multiple_relations_for_same_arguments(
             # nor as skipped in statistics.
             assert candidate_relation_tuples == []
             if collect_statistics:
-                assert (
-                    caplog.messages[0] == "statistics:\n"
-                    "|                        |   per:founded_by |   per:founder |   all_relations |\n"
-                    "|:-----------------------|-----------------:|--------------:|----------------:|\n"
-                    "| available              |                1 |             1 |               2 |\n"
-                    "| skipped_same_arguments |                1 |             1 |               2 |"
-                )
+                assert statistics == {
+                    ("available", "per:founded_by"): 1,
+                    ("available", "per:founder"): 1,
+                    ("skipped_same_arguments", "per:founder"): 1,
+                    ("skipped_same_arguments", "per:founded_by"): 1,
+                }
             else:
+                assert len(caplog.messages) == 1
                 assert caplog.messages[0] == expected_warning
         else:
             # all conflicting relations go into the same direction, so we can create a candidate (negative)
             # relation for the other direction.
             assert candidate_relation_tuples == [(("PER", "B"), "no_relation", ("PER", "A"))]
             if collect_statistics:
-                assert (
-                    caplog.messages[0] == "statistics:\n"
-                    "|                        |   no_relation |   per:founded_by |   per:founder |   all_relations |\n"
-                    "|:-----------------------|--------------:|-----------------:|--------------:|----------------:|\n"
-                    "| available              |             0 |                1 |             1 |               2 |\n"
-                    "| skipped_same_arguments |             0 |                1 |             1 |               2 |\n"
-                    "| used                   |             1 |                0 |             0 |               0 |\n"
-                    "| used %                 |           inf |                0 |             0 |               0 |"
-                )
+                assert statistics == {
+                    ("available", "per:founded_by"): 1,
+                    ("available", "per:founder"): 1,
+                    ("skipped_same_arguments", "per:founded_by"): 1,
+                    ("skipped_same_arguments", "per:founder"): 1,
+                    ("used", "no_relation"): 1,
+                }
             else:
+                assert len(caplog.messages) == 1
                 assert caplog.messages[0] == expected_warning
 
 
-def test_encode_input_handle_relations_with_same_arguments_unknown_value(caplog):
+def test_encode_input_handle_relations_with_same_arguments_unknown_value():
     taskmodule = RETextClassificationWithIndicesTaskModule(
         relation_annotation="relations",
         tokenizer_name_or_path="bert-base-cased",
@@ -1282,14 +1276,12 @@ def test_encode_input_duplicated_relations(
         ]
     )
     taskmodule.prepare([document])
-    encodings = taskmodule.encode_input(document)
+    with caplog.at_level(logging.WARNING):
+        encodings = taskmodule.encode_input(document)
 
-    with caplog.at_level(logging.INFO):
-        taskmodule.show_statistics()
-    if collect_statistics:
-        assert len(caplog.messages) == 2
-    else:
-        assert len(caplog.messages) == 1
+    statistics = taskmodule.get_statistics()
+
+    assert len(caplog.messages) == 1
     assert (
         caplog.messages[0] == "doc.id=test_doc: Relation annotation "
         "`('per:founded_by', (('PER', 'A'), ('PER', 'B')))` is duplicated. We keep "
@@ -1307,25 +1299,18 @@ def test_encode_input_duplicated_relations(
             (("PER", "B"), "no_relation", ("PER", "A")),
         ]
         if collect_statistics:
-            assert (
-                caplog.messages[-1] == "statistics:\n"
-                "|           |   no_relation |   per:founded_by |   all_relations |\n"
-                "|:----------|--------------:|-----------------:|----------------:|\n"
-                "| available |             0 |                1 |               1 |\n"
-                "| used      |             1 |                1 |               1 |\n"
-                "| used %    |           inf |              100 |             100 |"
-            )
+            assert statistics == {
+                ("available", "per:founded_by"): 1,
+                ("used", "no_relation"): 1,
+                ("used", "per:founded_by"): 1,
+            }
     else:
         assert candidate_relation_tuples == [(("PER", "A"), "per:founded_by", ("PER", "B"))]
         if collect_statistics:
-            assert (
-                caplog.messages[-1] == "statistics:\n"
-                "|           |   per:founded_by |\n"
-                "|:----------|-----------------:|\n"
-                "| available |                1 |\n"
-                "| used      |                1 |\n"
-                "| used %    |              100 |"
-            )
+            assert statistics == {
+                ("available", "per:founded_by"): 1,
+                ("used", "per:founded_by"): 1,
+            }
 
 
 def test_encode_input_argument_role_unknown(documents):
@@ -1966,7 +1951,7 @@ def test_encode_input_with_max_argument_distance_tokens(distance_type):
     assert relation.label == "per:employee_of"
 
 
-def test_encode_input_with_unknown_label(caplog):
+def test_encode_input_with_unknown_label():
     taskmodule = RETextClassificationWithIndicesTaskModule(
         relation_annotation="relations",
         tokenizer_name_or_path="bert-base-cased",
@@ -1986,16 +1971,8 @@ def test_encode_input_with_unknown_label(caplog):
     task_encodings = taskmodule.encode_input(doc)
     assert len(task_encodings) == 0
 
-    with caplog.at_level(logging.INFO):
-        taskmodule.show_statistics()
-    assert len(caplog.messages) == 1
-    assert (
-        caplog.messages[0] == "statistics:\n"
-        "|                       |   unknown |\n"
-        "|:----------------------|----------:|\n"
-        "| available             |         1 |\n"
-        "| skipped_unknown_label |         1 |"
-    )
+    statistics = taskmodule.get_statistics()
+    assert statistics == {("available", "unknown"): 1, ("skipped_unknown_label", "unknown"): 1}
 
 
 def test_encode_with_empty_partition_layer(documents):
@@ -2173,27 +2150,25 @@ def test_encode_with_log_first_n_examples(caplog):
 
 
 @pytest.mark.skipif(condition=not _TABULATE_AVAILABLE, reason="requires the 'tabulate' package")
-def test_encode_with_collect_statistics(documents, caplog):
+def test_encode_with_collect_statistics(documents):
     taskmodule = RETextClassificationWithIndicesTaskModule(
         relation_annotation="relations",
         tokenizer_name_or_path="bert-base-cased",
         collect_statistics=True,
     )
     taskmodule.prepare(documents)
-    # we need to set the log level to INFO, otherwise the log messages are not captured
-    with caplog.at_level(logging.INFO):
-        task_encodings = taskmodule.encode(documents)
+    task_encodings = taskmodule.encode(documents)
+    statistics = taskmodule.get_statistics()
     assert len(task_encodings) == 7
 
-    assert len(caplog.messages) == 1
-    assert caplog.messages[0] == (
-        "statistics:\n"
-        "|           |   org:founded_by |   per:employee_of |   per:founder |   all_relations |\n"
-        "|:----------|-----------------:|------------------:|--------------:|----------------:|\n"
-        "| available |                2 |                 3 |             2 |               7 |\n"
-        "| used      |                2 |                 3 |             2 |               7 |\n"
-        "| used %    |              100 |               100 |           100 |             100 |"
-    )
+    assert statistics == {
+        ("available", "org:founded_by"): 2,
+        ("available", "per:employee_of"): 3,
+        ("available", "per:founder"): 2,
+        ("used", "org:founded_by"): 2,
+        ("used", "per:employee_of"): 3,
+        ("used", "per:founder"): 2,
+    }
 
 
 def test_get_global_attention(taskmodule, batch, cfg):


### PR DESCRIPTION
to have the labels (which may be a lot) as index for improved readability and to allow to keep counts as int columns (dtypes are per-column, not per-row)

Also for tests not meant to test statistics output format, use get_statistics() instead of show_statistics() and capturing info messages. This will make tests independent from any formatting changes we may do in show_statistics()


TODO:
- [x] update all TaskModule tests checking `show_statistics()` output to check `get_statistics()` output instead which should be more reliable