### PR TITLE
remove deprecated `(Iterable)TaskEncodingDataset` from `TaskModuleWithDocumentConverter`

### DIFF
--- a/src/pie_modules/taskmodules/common/taskmodule_with_document_converter.py
+++ b/src/pie_modules/taskmodules/common/taskmodule_with_document_converter.py
@@ -3,9 +3,7 @@ from typing import Generic, Iterable, Iterator, Optional, Sequence, Type, TypeVa
 
 from pie_core import (
     Document,
-    IterableTaskEncodingDataset,
     TaskEncoding,
-    TaskEncodingDataset,
     TaskEncodingSequence,
     TaskModule,
 )
@@ -80,8 +78,6 @@ class TaskModuleWithDocumentConverter(
         Sequence[TaskEncodingType],
         TaskEncodingSequence[TaskEncodingType, DocumentType],
         Iterator[TaskEncodingType],
-        TaskEncodingDataset[TaskEncodingType],
-        IterableTaskEncodingDataset[TaskEncodingType],
     ]:
         converted_documents: Union[DocumentType, Iterable[DocumentType]]
         if isinstance(documents, Document):


### PR DESCRIPTION
to work with next pie-core version, see https://github.com/ArneBinder/pie-core/pull/61